### PR TITLE
Add basic unit tests for TestSet and Submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Environment
 *~
-.swo
-.swp
+*.swo
+*.swp
 
 # Python
 *.pyc
@@ -10,7 +10,7 @@
 venv
 
 # OCELoT
-db.sqlite3
+db.sqlite3*
 ocelot/local_settings.py
 submissions
 testsets

--- a/leaderboard/models.py
+++ b/leaderboard/models.py
@@ -206,7 +206,10 @@ class TestSet(models.Model):
         )
 
     def _create_text_files(self):
-        """Creates test set text files."""
+        """
+        Creates test set text files from SGML files.
+        If files are already in text format, do nothing.
+        """
         if self.file_format == TEXT_FILE:
             return
 

--- a/leaderboard/testdata/newstest2019-ende-ref.de.sgm
+++ b/leaderboard/testdata/newstest2019-ende-ref.de.sgm
@@ -1,0 +1,97 @@
+<refset setid="newstest2019" srclang="any" trglang="de">
+<doc sysid="ref" docid="bbc.381790" genre="news" origlang="en">
+<p>
+<seg id="1">Walisische Ageordnete sorgen sich "wie Dödel auszusehen"</seg>
+<seg id="2">Es herrscht Bestürzung unter einigen Mitgliedern der Versammlung über einen Vorschlag, der ihren Titel zu MWPs (Mitglied der walisischen Parlament) ändern soll.</seg>
+<seg id="3">Der Grund dafür waren Pläne, den Namen der Nationalversammlung in Walisisches Parlament zu ändern.</seg>
+<seg id="4">Mitglieder aller Parteien der Nationalversammlung haben Bedenken, dass sie sich dadurch Spott aussetzen könnten.</seg>
+<seg id="5">Ein Labour-Abgeordneter sagte, dass seine Gruppe "sich mit Twp und Pwp reimt".</seg>
+<seg id="6">Hinweis für den Leser: „twp“ im Walisischen bedeutet „bescheuert“ und „pwp“ bedeutet „Kacke“.</seg>
+<seg id="7">Ein Versammlungsmitglied von Plaid Cymru sagte, die Gruppe als Ganzes sei "nicht glücklich" und hat Alternativen vorgeschlagen.</seg>
+<seg id="8">Ein walisischer Konservativer sagte, seine Gruppe wäre „offen“ für eine Namensänderung, wies aber darauf hin, dass es von „MWP“ (Mitglied des Walisischen Parlaments) nur ein kurzer verbaler Sprung zu „Muppet“ ist.</seg>
+<seg id="9">Hinweis: Der walisische Buchstabe W wird ähnlich ausgesprochen wie das U im Englischen.</seg>
+<seg id="10">Die Kommission der Nationalversammlung, die gerade an einem Gesetzentwurf für die Namensänderungen arbeitet, sagte: „Die finale Entscheidung über die Bezeichnung der Mitglieder der Nationalversammlung liegt natürlich bei den Mitgliedern selbst.“</seg>
+<seg id="11">Mit dem Government of Wales Act 2017 erhielt das walisische Parlament die Möglichkeit, seinen Namen zu ändern.</seg>
+<seg id="12">Im Juni vergangenen Jahres hat die Kommission die Ergebnisse einer öffentlichen Anhörung zu den Vorschlägen veröffentlicht, wonach die Namensänderung in Walisisches Parlament breite Zustimmung findet.</seg>
+<seg id="13">Bei der Frage um den Titel der Versammlungsmitglieder bevorzugte die Kommission walisischen Parlamentsmitglieder oder WMPs, jedoch bekam die MWP-Option die meiste Unterstützung in einer öffentlichen Befragung.</seg>
+<seg id="14">Mitglieder des walisischen Parlaments schlagen offenbar alternative Optionen vor, aber der Kampf zu einem Konsens zu gelangen, könnte der Vorsitzenden Elin JONES Kopfschmerzen bereiten. Von ihr wird erwartet, dass sie einen Gesetzesentwurf für diese Änderungen in den nächsten Wochen vorlegt.</seg>
+<seg id="15">Die Rechtsvorschriften über die Reformen wird Änderungen in der Arbeitsweise der Versammlung beinhalten, einschließlich der Vorschriften für die Disqualifikation von Mitgliedern des walisischen Parlaments und die Gestaltung des Auschusssystems.</seg>
+<seg id="16">Die Mitglieder der Nationalversammlung können bei der Debatte um das Gesetz entscheiden, wie sie genannt werden sollen.</seg>
+</p>
+</doc>
+<doc sysid="ref" docid="rt.com.91337" genre="news" origlang="en">
+<p>
+<seg id="1">Mazedonier halten über die Änderung des Landesnamens ein Referendum ab.</seg>
+<seg id="2">Am Sonntag stimmen die Wahlberechtigten über die Änderung des Landesnamens zu „Republik Nordmazedonien“ ab.</seg>
+<seg id="3">Die Volksabstimmung wird abgehalten, um einen jahrzehntelangen Streit mit dem benachbarten Griechenland beizulegen, in dem eine Provinz den Namen Mazedonien trägt.</seg>
+<seg id="4">Athen beharrt seit langem darauf, dass der Name seines nördlichen Nachbarn einen Anspruch auf sein Territorium darstellt und hat wiederholt Einspruch gegen seinen Aufnahmeantrag für die EU und die NATO erhoben.</seg>
+<seg id="5">Der mazedonische Präsident Gjorge Ivanov, ein Gegner des Referendums bezüglich der Namensänderung, hat gesagt, er werde die Abstimmung ignorieren.</seg>
+<seg id="6">Die Befürworter des Referendums, einschließlich des Premierministers Zoran Zaev, argumentieren jedoch, dass die Namensänderung ganz einfach der Preis ist, den man für den Beitritt zur EU und zur NATO zahlen muss.</seg>
+</p>
+</doc>
+<doc sysid="ref" docid="nytimes.184853" genre="news" origlang="en">
+<p>
+<seg id="1">Die Glocken von St. Martin verstummenn, da Kirchen in Harlem Probleme haben</seg>
+<seg id="2">"Historisch gesehen haben die alten Leute, mit denen ich gesprochen habe, gesagt, dass es an jeder Ecke eine Bar und eine Kirche gab", sagte Herr Adams.</seg>
+<seg id="3">„Heute gibt es weder noch."</seg>
+<seg id="4">Er sagte, das Verschwinden von Kneipen sei verständlich.</seg>
+<seg id="5">"Menschen knüpfen Komtakte auf eine andere Art und Weise", heutzutage sagte er.</seg>
+<seg id="6">"Kneipen sind keine Wohnzimmer mehr in der Nachbarschaft, in denen man sich regelmäßig trifft."</seg>
+<seg id="7">Was Kirchen angeht, fürchtet er, dass das Geld aus dem Verkauf von Vermögenswerten nicht so lange Bestand haben wird, wie die Anführer es erwarten.</seg>
+<seg id="8">Kirchen könnten durch Mehrfamilienhäuser mit Eigentumswohnungen ersetzt werden, die mit der Art von Menschen gefüllt sind, die den verbleibenden Zufluchtsstätten des Stadtteils nicht helfen werden.</seg>
+<seg id="9">Die überwältigende Mehrheit der Menschen, die Eigentumswohnungen in diesen Gebäuden kaufen, wird weiß sein, sagte er, "und wird daher den Tag, an dem diese Kirchen ganz geschlossen werden, beschleunigen, da es unwahrscheinlich ist, dass die meisten dieser Personen, die in diese Eigentumswohnungen einziehen, Mitglieder dieser Kirchen werden."</seg>
+<seg id="10">Beide Kirchen wurden von weißen Gemeinden gebaut, bevor Harlem 1870 zur schwarzen Metropole wurde – Metropolitan Community, St. Martin's ein Jahrzehnt später.</seg>
+<seg id="11">Die ursprüngliche weiße methodistische Gemeinde zog in den 1930er Jahren aus.</seg>
+<seg id="12">Eine schwarze Gemeinde, die in der Nähe eine Religion ausübten, erwarb das Gebäude.</seg>
+<seg id="13">St. Martin's wurde von einer schwarzen Gemeinde unter dem Pfarrer John Howard Johnson übernommen, der einen Boykott der Einzelhändler in der 125. Straße, einer Hauptstraße zum Einkaufen in Harlem, anführte, die sich der Einstellung oder Förderung von Schwarzen widersetzte.</seg>
+<seg id="14">Ein Brand im Jahr 1939 hinterließ das Gebäude schwer beschädigt, aber als die Gemeindemitglieder von Pater Johnson Pläne zum Wiederaufbau machten, beauftragten sie das Glockenspiel.</seg>
+<seg id="15">Pfarrer David Johnson, Sohn von Pater Johnson und Nachfolger in St. Martin's, nannte das Glockenspiel stolz „die Glocken der Armen."</seg>
+<seg id="16">Der Experte, der im Juli das Glockenspiel spielte, nannte es noch etwas anderes: "Ein Kulturschatz" und "ein unersetzliches historisches Instrument".</seg>
+<seg id="17">Der Experte, Tiffany Ng von der University of Michigan, stellte auch fest, dass es das erste Glockenspiel der Welt war, das von einem schwarzen Musiker, Dionisio A. Lind, gespielt wurde, der vor 18 Jahren in das größere Glockenspiel an der Riverside Church wechselte.</seg>
+<seg id="18">Herr Merriweather sagte, dass St. Martin's ihn nicht ersetzt hat.</seg>
+<seg id="19">Was sich in den letzten Monaten bei St. Martin abgespielt hat, war eine komplizierte Geschichte von Architekten und Bauunternehmern, einige wurden von den Laienführern der Kirche, andere von der Bischofsdiözese eingebracht.</seg>
+<seg id="20">Die Sakristei – das Leitungsorgan der Pfarrei, das sich aus Laienführern zusammensetzt – schrieb im Juli an die Diözese mit der Sorge, dass die Diözese "versuchen würde, die Kosten an die Sakristei weiterzugeben", obwohl die Sakristei nicht an der Beauftragung der Architekten und Auftragnehmer der Diözese beteiligt war.</seg>
+<seg id="21">Einige Gemeindemitglieder beklagten einen Mangel an Transparenz seitens der Diözese.</seg>
+</p>
+</doc>
+<doc sysid="ref" docid="upi.176266" genre="news" origlang="en">
+<p>
+<seg id="1">Hai verletzt 13-jährigen Jungen beim Hummertauchen in Kalifornien</seg>
+<seg id="2">Am Samstag griff ein Hai einen 13-jährigen Jungen an und verletzte ihn, während er in Kalifornien am Eröffnungstag der Hummersaison nach Hummern tauchte, sagten Beamte.</seg>
+<seg id="3">Der Angriff fand kurz vor sieben Uhr morgens nahe dem Strand von Beacon in Encinitas statt.</seg>
+<seg id="4">Chad Hammel sagte KSWB-TV in San Diego, er habe mit Freunden für eine halbe Stunde am Samstagmorgen getaucht, als er den Jungen um Hilfe schreien hörte. Er sei dann mit den anderen rübergepaddelt, um ihn aus dem Wasser zu retten.</seg>
+<seg id="5">„Zuerst dachte ich, jemand freut sich, weil er einen Hummer gefangen hat“, sagte Hammel. Aber dann bemerkte ich, dass jemand schrie: „Ich wurde gebissen!“</seg>
+<seg id="6">Ich wurde gebissen!</seg>
+<seg id="7">Sein ganzes Schlüsselbein wurde aufgerissen, sagte Hammel, er stellte dies fest als er zu dem Jungen kam.</seg>
+<seg id="8">Ich schrie alle an, damit sie aus dem Wasser herauskommen: "Da ist ein Hai im Wasser!" sagte Hammel.</seg>
+<seg id="9">Der Junge wurde ins Rady Children's Hospital in San Diego gebracht, wo sein Zustand als kritisch dokumentiert wurde.</seg>
+<seg id="10">Die für den Angriff verantwortliche Haiart ist unbekannt.</seg>
+<seg id="11">Rettungsschwimmer Kapitän Larry Giles sagte bei einer Medienbesprechung, dass ein Hai einige Wochen zuvor in der Gegend gesichtet worden war, aber es wurde festgestellt, dass es sich nicht um eine gefährliche Haiart handelt.</seg>
+<seg id="12">Giles fügte im Oberkörperbereich seines Opfers traumatische Verletzungen hinzu.</seg>
+<seg id="13">Beamte schlossen den Zugang zum Strand von Ponto Beach in Casablad zu Swami's in Ecinitas für 48 Stunden aus Sicherheitsgründen.</seg>
+<seg id="14">Giles stellte fest, dass es mehr als 135 Haiarten in der Gegend gibt, aber die meisten gelten nicht als gefährlich.</seg>
+</p>
+</doc>
+<doc sysid="ref" docid="guardian.221754" genre="news" origlang="en">
+<p>
+<seg id="1">Sainsbury plant, den britischen Beauty-Markt zu erobern</seg>
+<seg id="2">Sainsbury's übernimmt Boots, Superdrug und Debenhams mit Regalen mit Schönheitsprodukten im Kaufhausstil, die mit Fachassistenten besetzt sind.</seg>
+<seg id="3">Im Rahmen eines umfangreichen Pushs in den britische Schönheitsmarkt in Großbritannien, der weiter wächst und £2.8bn wert ist, werden Mode-und Homeware-Verkäufe zurückfallen. Die größeren 11 Filialen, die das Land getestet und im nächsten Jahr wieder in mehr Läden gebracht hat, um Erfolg zu zeigen.</seg>
+<seg id="4">Die Idee, in den Beauty-Markt zu investieren, ist daraus entstanden, dass Supermärkte nach Möglichkeiten suchen, den Regalplatz, der früher für Fernseher, Mikrowellen und Haushaltswaren verwendet wurde, für neue Produkte zu nutzen.</seg>
+<seg id="5">Sainsbury teilte mit, dass das Angebot an Beauty-Produkten auf 3000 Produkte verdoppelt werde, indem erstmals auch Marken wie Revlon, Essie, Tweezerman und Dr. PawPaw in das Produktportfolio aufgenommen werden.</seg>
+<seg id="6">Auch bestehende Sortimente von L'Oreal, Maybelline und Burt's Bees werden mehr Platz in Markenbereichen erhalten, ähnlich wie sie in Geschäften wie Boots zu finden sind.</seg>
+<seg id="7">Die Supermarktkette belebt auch ihre hauseigene Makeup-Marke „Boutique“ neu, die zahlreiche bei jungen Käufern beliebte vegane Produkte im Angebot hat.</seg>
+<seg id="8">Darüber hinaus testet der Parfümhändler Fragrance Shop Konzessionen in zwei Sainsburys Geschäften, von denen das erste letzte Woche in Croydon, Süd-London, eröffnet wurde, während ein zweites Ende dieses Jahres in Selly Oak, Birmingham, eröffnet wird.</seg>
+<seg id="9">Online-Shopping und eine Verlagerung hin zum täglichen Einkauf kleiner Mengen Lebensmittel in Nachbarschaftsläden haben zur Folge, dass Supermärkte mehr tun müssen, um die Menschen zum Besuch zu bewegen.</seg>
+<seg id="10">Mike Coupe, der Chef von Sainsbury's, hat gesagt, dass die Verkaufsstellen in zunehmendem Maße wie Warenhäuser aussehen werden, da die Supermarktkette versucht Discounter wie Aldi und Lidl mit mehr Dienstleistungen und Non-Food zu bekämpfen.</seg>
+<seg id="11">Sainsbury's hat Argos-Outlets in Hunderten von Geschäften platziert und auch eine Reihe von Habitats eingeführt, seit es beide Ketten vor zwei Jahren gekauft hat, was angeblich den Lebensmittelverkauf gestärkt und die Akquisitionen profitabler gemacht hat.</seg>
+<seg id="12">Der frühere Versuch des Supermarktes, seine Schönheits- und Apothekenabteilungen zu überarbeiten, endete mit einem Misserfolg.</seg>
+<seg id="13">Sainsbury hat ein Joint Venture mit Boots in den frühen 2000er Jahren getestet, aber es endete unetschieden, und die Einnahmen aus den Geschäften der Apotheken konnten nicht geteilt werden.</seg>
+<seg id="14">Die neue Strategie kommt, nachdem Sainsbury's sein 281-Filialen-Apothekengeschäft vor drei Jahren für 125 Millionen Pfund an Celesio, den Eigentümer der Lloyds Pharmacy Kette, verkauft hat.</seg>
+<seg id="15">Laut Angaben soll Lloyds ebenfalls beteiligt sein. In vier Lloyds-Stores soll das Angebot an Luxus-Hautpflegeprodukten von Marken wie La Roche-Posay und Vichy stark erweitert werden.</seg>
+<seg id="16">Paul Mills-Hicks, Werbechef von Sainsbury, sagte: „Wir haben das Erscheinungsbild unserer Regale für Schönheitsprodukte verändert, um die Ausstattung für unsere Kunden zu verbessern.</seg>
+<seg id="17">Zusätzlich haben wir in die Schulung von Mitarbeitern investiert, die dem Kunden beratend zur Seite stehen sollen.</seg>
+<seg id="18">Unser Markenportfolio lässt keine Wünsche offen. Das elegante Ambiente, die günstige Innenstadtlage und ein revolutioniertes Kauferlebnis machen uns zu einem beliebten Anlaufziel in Beauty-Fragen.</seg>
+</p>
+</doc>
+</refset>

--- a/leaderboard/testdata/newstest2019-ende-ref.de.txt
+++ b/leaderboard/testdata/newstest2019-ende-ref.de.txt
@@ -1,0 +1,75 @@
+Walisische Ageordnete sorgen sich "wie Dödel auszusehen"
+Es herrscht Bestürzung unter einigen Mitgliedern der Versammlung über einen Vorschlag, der ihren Titel zu MWPs (Mitglied der walisischen Parlament) ändern soll.
+Der Grund dafür waren Pläne, den Namen der Nationalversammlung in Walisisches Parlament zu ändern.
+Mitglieder aller Parteien der Nationalversammlung haben Bedenken, dass sie sich dadurch Spott aussetzen könnten.
+Ein Labour-Abgeordneter sagte, dass seine Gruppe "sich mit Twp und Pwp reimt".
+Hinweis für den Leser: „twp“ im Walisischen bedeutet „bescheuert“ und „pwp“ bedeutet „Kacke“.
+Ein Versammlungsmitglied von Plaid Cymru sagte, die Gruppe als Ganzes sei "nicht glücklich" und hat Alternativen vorgeschlagen.
+Ein walisischer Konservativer sagte, seine Gruppe wäre „offen“ für eine Namensänderung, wies aber darauf hin, dass es von „MWP“ (Mitglied des Walisischen Parlaments) nur ein kurzer verbaler Sprung zu „Muppet“ ist.
+Hinweis: Der walisische Buchstabe W wird ähnlich ausgesprochen wie das U im Englischen.
+Die Kommission der Nationalversammlung, die gerade an einem Gesetzentwurf für die Namensänderungen arbeitet, sagte: „Die finale Entscheidung über die Bezeichnung der Mitglieder der Nationalversammlung liegt natürlich bei den Mitgliedern selbst.“
+Mit dem Government of Wales Act 2017 erhielt das walisische Parlament die Möglichkeit, seinen Namen zu ändern.
+Im Juni vergangenen Jahres hat die Kommission die Ergebnisse einer öffentlichen Anhörung zu den Vorschlägen veröffentlicht, wonach die Namensänderung in Walisisches Parlament breite Zustimmung findet.
+Bei der Frage um den Titel der Versammlungsmitglieder bevorzugte die Kommission walisischen Parlamentsmitglieder oder WMPs, jedoch bekam die MWP-Option die meiste Unterstützung in einer öffentlichen Befragung.
+Mitglieder des walisischen Parlaments schlagen offenbar alternative Optionen vor, aber der Kampf zu einem Konsens zu gelangen, könnte der Vorsitzenden Elin JONES Kopfschmerzen bereiten. Von ihr wird erwartet, dass sie einen Gesetzesentwurf für diese Änderungen in den nächsten Wochen vorlegt.
+Die Rechtsvorschriften über die Reformen wird Änderungen in der Arbeitsweise der Versammlung beinhalten, einschließlich der Vorschriften für die Disqualifikation von Mitgliedern des walisischen Parlaments und die Gestaltung des Auschusssystems.
+Die Mitglieder der Nationalversammlung können bei der Debatte um das Gesetz entscheiden, wie sie genannt werden sollen.
+Mazedonier halten über die Änderung des Landesnamens ein Referendum ab.
+Am Sonntag stimmen die Wahlberechtigten über die Änderung des Landesnamens zu „Republik Nordmazedonien“ ab.
+Die Volksabstimmung wird abgehalten, um einen jahrzehntelangen Streit mit dem benachbarten Griechenland beizulegen, in dem eine Provinz den Namen Mazedonien trägt.
+Athen beharrt seit langem darauf, dass der Name seines nördlichen Nachbarn einen Anspruch auf sein Territorium darstellt und hat wiederholt Einspruch gegen seinen Aufnahmeantrag für die EU und die NATO erhoben.
+Der mazedonische Präsident Gjorge Ivanov, ein Gegner des Referendums bezüglich der Namensänderung, hat gesagt, er werde die Abstimmung ignorieren.
+Die Befürworter des Referendums, einschließlich des Premierministers Zoran Zaev, argumentieren jedoch, dass die Namensänderung ganz einfach der Preis ist, den man für den Beitritt zur EU und zur NATO zahlen muss.
+Die Glocken von St. Martin verstummenn, da Kirchen in Harlem Probleme haben
+"Historisch gesehen haben die alten Leute, mit denen ich gesprochen habe, gesagt, dass es an jeder Ecke eine Bar und eine Kirche gab", sagte Herr Adams.
+„Heute gibt es weder noch."
+Er sagte, das Verschwinden von Kneipen sei verständlich.
+"Menschen knüpfen Komtakte auf eine andere Art und Weise", heutzutage sagte er.
+"Kneipen sind keine Wohnzimmer mehr in der Nachbarschaft, in denen man sich regelmäßig trifft."
+Was Kirchen angeht, fürchtet er, dass das Geld aus dem Verkauf von Vermögenswerten nicht so lange Bestand haben wird, wie die Anführer es erwarten.
+Kirchen könnten durch Mehrfamilienhäuser mit Eigentumswohnungen ersetzt werden, die mit der Art von Menschen gefüllt sind, die den verbleibenden Zufluchtsstätten des Stadtteils nicht helfen werden.
+Die überwältigende Mehrheit der Menschen, die Eigentumswohnungen in diesen Gebäuden kaufen, wird weiß sein, sagte er, "und wird daher den Tag, an dem diese Kirchen ganz geschlossen werden, beschleunigen, da es unwahrscheinlich ist, dass die meisten dieser Personen, die in diese Eigentumswohnungen einziehen, Mitglieder dieser Kirchen werden."
+Beide Kirchen wurden von weißen Gemeinden gebaut, bevor Harlem 1870 zur schwarzen Metropole wurde – Metropolitan Community, St. Martin's ein Jahrzehnt später.
+Die ursprüngliche weiße methodistische Gemeinde zog in den 1930er Jahren aus.
+Eine schwarze Gemeinde, die in der Nähe eine Religion ausübten, erwarb das Gebäude.
+St. Martin's wurde von einer schwarzen Gemeinde unter dem Pfarrer John Howard Johnson übernommen, der einen Boykott der Einzelhändler in der 125. Straße, einer Hauptstraße zum Einkaufen in Harlem, anführte, die sich der Einstellung oder Förderung von Schwarzen widersetzte.
+Ein Brand im Jahr 1939 hinterließ das Gebäude schwer beschädigt, aber als die Gemeindemitglieder von Pater Johnson Pläne zum Wiederaufbau machten, beauftragten sie das Glockenspiel.
+Pfarrer David Johnson, Sohn von Pater Johnson und Nachfolger in St. Martin's, nannte das Glockenspiel stolz „die Glocken der Armen."
+Der Experte, der im Juli das Glockenspiel spielte, nannte es noch etwas anderes: "Ein Kulturschatz" und "ein unersetzliches historisches Instrument".
+Der Experte, Tiffany Ng von der University of Michigan, stellte auch fest, dass es das erste Glockenspiel der Welt war, das von einem schwarzen Musiker, Dionisio A. Lind, gespielt wurde, der vor 18 Jahren in das größere Glockenspiel an der Riverside Church wechselte.
+Herr Merriweather sagte, dass St. Martin's ihn nicht ersetzt hat.
+Was sich in den letzten Monaten bei St. Martin abgespielt hat, war eine komplizierte Geschichte von Architekten und Bauunternehmern, einige wurden von den Laienführern der Kirche, andere von der Bischofsdiözese eingebracht.
+Die Sakristei – das Leitungsorgan der Pfarrei, das sich aus Laienführern zusammensetzt – schrieb im Juli an die Diözese mit der Sorge, dass die Diözese "versuchen würde, die Kosten an die Sakristei weiterzugeben", obwohl die Sakristei nicht an der Beauftragung der Architekten und Auftragnehmer der Diözese beteiligt war.
+Einige Gemeindemitglieder beklagten einen Mangel an Transparenz seitens der Diözese.
+Hai verletzt 13-jährigen Jungen beim Hummertauchen in Kalifornien
+Am Samstag griff ein Hai einen 13-jährigen Jungen an und verletzte ihn, während er in Kalifornien am Eröffnungstag der Hummersaison nach Hummern tauchte, sagten Beamte.
+Der Angriff fand kurz vor sieben Uhr morgens nahe dem Strand von Beacon in Encinitas statt.
+Chad Hammel sagte KSWB-TV in San Diego, er habe mit Freunden für eine halbe Stunde am Samstagmorgen getaucht, als er den Jungen um Hilfe schreien hörte. Er sei dann mit den anderen rübergepaddelt, um ihn aus dem Wasser zu retten.
+„Zuerst dachte ich, jemand freut sich, weil er einen Hummer gefangen hat“, sagte Hammel. Aber dann bemerkte ich, dass jemand schrie: „Ich wurde gebissen!“
+Ich wurde gebissen!
+Sein ganzes Schlüsselbein wurde aufgerissen, sagte Hammel, er stellte dies fest als er zu dem Jungen kam.
+Ich schrie alle an, damit sie aus dem Wasser herauskommen: "Da ist ein Hai im Wasser!" sagte Hammel.
+Der Junge wurde ins Rady Children's Hospital in San Diego gebracht, wo sein Zustand als kritisch dokumentiert wurde.
+Die für den Angriff verantwortliche Haiart ist unbekannt.
+Rettungsschwimmer Kapitän Larry Giles sagte bei einer Medienbesprechung, dass ein Hai einige Wochen zuvor in der Gegend gesichtet worden war, aber es wurde festgestellt, dass es sich nicht um eine gefährliche Haiart handelt.
+Giles fügte im Oberkörperbereich seines Opfers traumatische Verletzungen hinzu.
+Beamte schlossen den Zugang zum Strand von Ponto Beach in Casablad zu Swami's in Ecinitas für 48 Stunden aus Sicherheitsgründen.
+Giles stellte fest, dass es mehr als 135 Haiarten in der Gegend gibt, aber die meisten gelten nicht als gefährlich.
+Sainsbury plant, den britischen Beauty-Markt zu erobern
+Sainsbury's übernimmt Boots, Superdrug und Debenhams mit Regalen mit Schönheitsprodukten im Kaufhausstil, die mit Fachassistenten besetzt sind.
+Im Rahmen eines umfangreichen Pushs in den britische Schönheitsmarkt in Großbritannien, der weiter wächst und £2.8bn wert ist, werden Mode-und Homeware-Verkäufe zurückfallen. Die größeren 11 Filialen, die das Land getestet und im nächsten Jahr wieder in mehr Läden gebracht hat, um Erfolg zu zeigen.
+Die Idee, in den Beauty-Markt zu investieren, ist daraus entstanden, dass Supermärkte nach Möglichkeiten suchen, den Regalplatz, der früher für Fernseher, Mikrowellen und Haushaltswaren verwendet wurde, für neue Produkte zu nutzen.
+Sainsbury teilte mit, dass das Angebot an Beauty-Produkten auf 3000 Produkte verdoppelt werde, indem erstmals auch Marken wie Revlon, Essie, Tweezerman und Dr. PawPaw in das Produktportfolio aufgenommen werden.
+Auch bestehende Sortimente von L'Oreal, Maybelline und Burt's Bees werden mehr Platz in Markenbereichen erhalten, ähnlich wie sie in Geschäften wie Boots zu finden sind.
+Die Supermarktkette belebt auch ihre hauseigene Makeup-Marke „Boutique“ neu, die zahlreiche bei jungen Käufern beliebte vegane Produkte im Angebot hat.
+Darüber hinaus testet der Parfümhändler Fragrance Shop Konzessionen in zwei Sainsburys Geschäften, von denen das erste letzte Woche in Croydon, Süd-London, eröffnet wurde, während ein zweites Ende dieses Jahres in Selly Oak, Birmingham, eröffnet wird.
+Online-Shopping und eine Verlagerung hin zum täglichen Einkauf kleiner Mengen Lebensmittel in Nachbarschaftsläden haben zur Folge, dass Supermärkte mehr tun müssen, um die Menschen zum Besuch zu bewegen.
+Mike Coupe, der Chef von Sainsbury's, hat gesagt, dass die Verkaufsstellen in zunehmendem Maße wie Warenhäuser aussehen werden, da die Supermarktkette versucht Discounter wie Aldi und Lidl mit mehr Dienstleistungen und Non-Food zu bekämpfen.
+Sainsbury's hat Argos-Outlets in Hunderten von Geschäften platziert und auch eine Reihe von Habitats eingeführt, seit es beide Ketten vor zwei Jahren gekauft hat, was angeblich den Lebensmittelverkauf gestärkt und die Akquisitionen profitabler gemacht hat.
+Der frühere Versuch des Supermarktes, seine Schönheits- und Apothekenabteilungen zu überarbeiten, endete mit einem Misserfolg.
+Sainsbury hat ein Joint Venture mit Boots in den frühen 2000er Jahren getestet, aber es endete unetschieden, und die Einnahmen aus den Geschäften der Apotheken konnten nicht geteilt werden.
+Die neue Strategie kommt, nachdem Sainsbury's sein 281-Filialen-Apothekengeschäft vor drei Jahren für 125 Millionen Pfund an Celesio, den Eigentümer der Lloyds Pharmacy Kette, verkauft hat.
+Laut Angaben soll Lloyds ebenfalls beteiligt sein. In vier Lloyds-Stores soll das Angebot an Luxus-Hautpflegeprodukten von Marken wie La Roche-Posay und Vichy stark erweitert werden.
+Paul Mills-Hicks, Werbechef von Sainsbury, sagte: „Wir haben das Erscheinungsbild unserer Regale für Schönheitsprodukte verändert, um die Ausstattung für unsere Kunden zu verbessern.
+Zusätzlich haben wir in die Schulung von Mitarbeitern investiert, die dem Kunden beratend zur Seite stehen sollen.
+Unser Markenportfolio lässt keine Wünsche offen. Das elegante Ambiente, die günstige Innenstadtlage und ein revolutioniertes Kauferlebnis machen uns zu einem beliebten Anlaufziel in Beauty-Fragen.

--- a/leaderboard/testdata/newstest2019-ende-src.en.sgm
+++ b/leaderboard/testdata/newstest2019-ende-src.en.sgm
@@ -1,0 +1,97 @@
+<srcset setid="newstest2019" srclang="any">
+<doc sysid="ref" docid="bbc.381790" genre="news" origlang="en">
+<p>
+<seg id="1">Welsh AMs worried about 'looking like muppets'</seg>
+<seg id="2">There is consternation among some AMs at a suggestion their title should change to MWPs (Member of the Welsh Parliament).</seg>
+<seg id="3">It has arisen because of plans to change the name of the assembly to the Welsh Parliament.</seg>
+<seg id="4">AMs across the political spectrum are worried it could invite ridicule.</seg>
+<seg id="5">One Labour AM said his group was concerned "it rhymes with Twp and Pwp."</seg>
+<seg id="6">For readers outside of Wales: In Welsh twp means daft and pwp means poo.</seg>
+<seg id="7">A Plaid AM said the group as a whole was "not happy" and has suggested alternatives.</seg>
+<seg id="8">A Welsh Conservative said his group was "open minded" about the name change, but noted it was a short verbal hop from MWP to Muppet.</seg>
+<seg id="9">In this context The Welsh letter w is pronounced similarly to the Yorkshire English pronunciation of the letter u.</seg>
+<seg id="10">The Assembly Commission, which is currently drafting legislation to introduce the name changes, said: "The final decision on any descriptors of what Assembly Members are called will of course be a matter for the members themselves."</seg>
+<seg id="11">The Government of Wales Act 2017 gave the Welsh assembly the power to change its name.</seg>
+<seg id="12">In June, the Commission published the results of a public consultation on the proposals which found broad support for calling the assembly a Welsh Parliament.</seg>
+<seg id="13">On the matter of the AMs' title, the Commission favoured Welsh Parliament Members or WMPs, but the MWP option received the most support in a public consultation.</seg>
+<seg id="14">AMs are apparently suggesting alternative options, but the struggle to reach consensus could be a headache for the Presiding Officer, Elin Jones, who is expected to submit draft legislation on the changes within weeks.</seg>
+<seg id="15">The legislation on the reforms will include other changes to the way the assembly works, including rules on disqualification of AMs and the design of the committee system.</seg>
+<seg id="16">AMs will get the final vote on the question of what they should be called when they debate the legislation.</seg>
+</p>
+</doc>
+<doc sysid="ref" docid="rt.com.91337" genre="news" origlang="en">
+<p>
+<seg id="1">Macedonians go to polls in referendum on changing country's name</seg>
+<seg id="2">Voters will vote Sunday on whether to change their country's name to the "Republic of North Macedonia."</seg>
+<seg id="3">The popular vote was set up in a bid to resolve a decades-long dispute with neighboring Greece, which has its own province called Macedonia.</seg>
+<seg id="4">Athens has long insisted that its northern neighbor's name represents a claim on its territory and has repeatedly objected to its membership bids for the EU and NATO.</seg>
+<seg id="5">Macedonian President Gjorge Ivanov, an opponent of the plebiscite on the name change, has said he will disregard the vote.</seg>
+<seg id="6">However, supporters of the referendum, including Prime Minister Zoran Zaev, argue that the name change is simply the price to pay to join the EU and NATO.</seg>
+</p>
+</doc>
+<doc sysid="ref" docid="nytimes.184853" genre="news" origlang="en">
+<p>
+<seg id="1">The Bells of St. Martin's Fall Silent as Churches in Harlem Struggle</seg>
+<seg id="2">"Historically, the old people I've talked to say there was a bar and a church on every corner," Mr. Adams said.</seg>
+<seg id="3">"Today, there's neither."</seg>
+<seg id="4">He said the disappearance of bars was understandable.</seg>
+<seg id="5">"People socialize in a different way" nowadays, he said.</seg>
+<seg id="6">"Bars are no longer neighborhood living rooms where people go on a regular basis."</seg>
+<seg id="7">As for churches, he worries that the money from selling assets will not last as long as leaders expect it to, "and sooner or later they'll be right back where they started."</seg>
+<seg id="8">Churches, he added, could be replaced by apartment buildings with condominiums filled with the kind of people who will not help the neighborhood's remaining sanctuaries.</seg>
+<seg id="9">"The overwhelming majority of people who buy condominiums in these buildings will be white," he said, "and therefore will hasten the day that these churches close altogether because it is unlikely that most of these people who move into these condominiums will become members of these churches."</seg>
+<seg id="10">Both churches were built by white congregations before Harlem became a black metropolis - Metropolitan Community in 1870, St. Martin's a decade later.</seg>
+<seg id="11">The original white Methodist congregation moved out in the 1930s.</seg>
+<seg id="12">A black congregation that had been worshiping nearby took title to the building.</seg>
+<seg id="13">St. Martin's was taken over by a black congregation under the Rev. John Howard Johnson, who led a boycott of retailers on 125th Street, a main street for shopping in Harlem, who resisted hiring or promoting blacks.</seg>
+<seg id="14">A fire in 1939 left the building badly damaged, but as Father Johnson's parishioners made plans to rebuild, they commissioned the carillon.</seg>
+<seg id="15">The Rev. David Johnson, Father Johnson's son and successor at St. Martin's, proudly called the carillon "the poor people's bells."</seg>
+<seg id="16">The expert who played the carillon in July called it something else: "A cultural treasure" and "an irreplaceable historical instrument."</seg>
+<seg id="17">The expert, Tiffany Ng of the University of Michigan, also noted that it was the first carillon in the world to be played by a black musician, Dionisio A. Lind, who moved to the larger carillon at the Riverside Church 18 years ago.</seg>
+<seg id="18">Mr. Merriweather said that St. Martin's did not replace him.</seg>
+<seg id="19">What has played out at St. Martin's over the last few months has been a complicated tale of architects and contractors, some brought in by the lay leaders of the church, others by the Episcopal diocese.</seg>
+<seg id="20">The vestry - the parish's governing body, made up of lay leaders - wrote the diocese in July with concerns that the diocese "would seek to pass along the costs" to the vestry, even though the vestry had not been involved in hiring the architects and contractors the diocese sent in.</seg>
+<seg id="21">Some parishioners complained of a lack of transparency on the diocese's part.</seg>
+</p>
+</doc>
+<doc sysid="ref" docid="upi.176266" genre="news" origlang="en">
+<p>
+<seg id="1">Shark injures 13-year-old on lobster dive in California</seg>
+<seg id="2">A shark attacked and injured a 13-year-old boy Saturday while he was diving for lobster in California on the opening day of lobster season, officials said.</seg>
+<seg id="3">The attack occurred just before 7 a.m. near Beacon's Beach in Encinitas.</seg>
+<seg id="4">Chad Hammel told KSWB-TV in San Diego he had been diving with friends for about half an hour Saturday morning when he heard the boy screaming for help and then paddled over with a group to help pull him out of the water.</seg>
+<seg id="5">Hammel said at first he thought it was just excitement of catching a lobster, but then he "realized that he was yelling, 'I got bit!</seg>
+<seg id="6">I got bit!'</seg>
+<seg id="7">His whole clavicle was ripped open," Hammel said he noticed once he got to the boy.</seg>
+<seg id="8">"I yelled at everyone to get out of the water: 'There's a shark in the water!'" Hammel added.</seg>
+<seg id="9">The boy was airlifted to Rady Children's Hospital in San Diego where he is listed in critical condition.</seg>
+<seg id="10">The species of shark responsible for the attack was unknown.</seg>
+<seg id="11">Lifeguard Capt. Larry Giles said at a media briefing that a shark had been spotted in the area a few weeks earlier, but it was determined not to be a dangerous species of shark.</seg>
+<seg id="12">Giles added the victim sustained traumatic injuries to his upper torso area.</seg>
+<seg id="13">Officials shut down beach access from Ponto Beach in Casablad to Swami's in Ecinitas for 48 hours for investigation and safety purposes.</seg>
+<seg id="14">Giles noted that there are more than 135 shark species in the area, but most are not considered dangerous.</seg>
+</p>
+</doc>
+<doc sysid="ref" docid="guardian.221754" genre="news" origlang="en">
+<p>
+<seg id="1">Sainsbury's plans push into UK beauty market</seg>
+<seg id="2">Sainsbury's is taking on Boots, Superdrug and Debenhams with department store-style beauty aisles staffed with specialist assistants.</seg>
+<seg id="3">As part of a substantial push into the UK's £2.8bn beauty market, which is continuing to grow while fashion and homeware sales fall back, the larger beauty aisles will be tested out in 11 stores around the country and taken to more stores next year if it proves a success.</seg>
+<seg id="4">The investment in beauty comes as supermarkets hunt for ways to use up shelf space once sued for TVs, microwaves and homeware.</seg>
+<seg id="5">Sainsbury's said it would be doubling the size of its beauty offering to up to 3,000 products, including brands such as Revlon, Essie, Tweezerman and Dr. PawPaw for the first time.</seg>
+<seg id="6">Existing ranges from L'Oreal, Maybelline and Burt's Bees will also get more space with branded areas similar to those found in shops like Boots.</seg>
+<seg id="7">The supermarket is also relaunching its Boutique makeup range so that the majority of products are vegan-friendly - something increasingly demanded by younger shoppers.</seg>
+<seg id="8">In addition, perfume retailer the Fragrance Shop will be testing out concessions in two Sainsbury's stores, the first of which opened in Croydon, south London, last week while a second opens in Selly Oak, Birmingham, later this year.</seg>
+<seg id="9">Online shopping and a shift towards buying small amounts of food daily at local convenience stores means supermarkets are having to do more to persuade people to visit.</seg>
+<seg id="10">Mike Coupe, the chief executive of Sainsbury's, has said the outlets will look increasingly like department stores as the supermarket chain tries to fight back against the discounters Aldi and Lidl with more services and non-food.</seg>
+<seg id="11">Sainsbury's has been putting Argos outlets in hundreds of stores and has also introduced a number of Habitats since it bought both chains two years ago, which it says has bolstered grocery sales and made the acquisitions more profitable.</seg>
+<seg id="12">The supermarket's previous attempt to revamp its beauty and pharmacy departments ended in failure.</seg>
+<seg id="13">Sainsbury's tested a joint venture with Boots in the early 2000s, but the tie-up ended after a row over how to split the revenues from the chemist's stores in its supermarkets.</seg>
+<seg id="14">The new strategy comes after Sainsbury's sold its 281-store pharmacy business to Celesio, the owner of the Lloyds Pharmacy chain, for £125m, three years ago.</seg>
+<seg id="15">It said Lloyds would play a role in the plan, by adding an extended range of luxury skincare brands including La Roche-Posay and Vichy in four stores.</seg>
+<seg id="16">Paul Mills-Hicks, Sainsbury's commercial director, said: "We've transformed the look and feel of our beauty aisles to enhance the environment for our customers.</seg>
+<seg id="17">We've also invested in specially trained colleagues who will be on hand to offer advice.</seg>
+<seg id="18">Our range of brands is designed to suit every need and the alluring environment and convenient locations mean we're now a compelling beauty destination which challenges the old way of shopping."</seg>
+</p>
+</doc>
+</srcset>

--- a/leaderboard/testdata/newstest2019-ende-src.en.txt
+++ b/leaderboard/testdata/newstest2019-ende-src.en.txt
@@ -1,0 +1,75 @@
+Welsh AMs worried about 'looking like muppets'
+There is consternation among some AMs at a suggestion their title should change to MWPs (Member of the Welsh Parliament).
+It has arisen because of plans to change the name of the assembly to the Welsh Parliament.
+AMs across the political spectrum are worried it could invite ridicule.
+One Labour AM said his group was concerned "it rhymes with Twp and Pwp."
+For readers outside of Wales: In Welsh twp means daft and pwp means poo.
+A Plaid AM said the group as a whole was "not happy" and has suggested alternatives.
+A Welsh Conservative said his group was "open minded" about the name change, but noted it was a short verbal hop from MWP to Muppet.
+In this context The Welsh letter w is pronounced similarly to the Yorkshire English pronunciation of the letter u.
+The Assembly Commission, which is currently drafting legislation to introduce the name changes, said: "The final decision on any descriptors of what Assembly Members are called will of course be a matter for the members themselves."
+The Government of Wales Act 2017 gave the Welsh assembly the power to change its name.
+In June, the Commission published the results of a public consultation on the proposals which found broad support for calling the assembly a Welsh Parliament.
+On the matter of the AMs' title, the Commission favoured Welsh Parliament Members or WMPs, but the MWP option received the most support in a public consultation.
+AMs are apparently suggesting alternative options, but the struggle to reach consensus could be a headache for the Presiding Officer, Elin Jones, who is expected to submit draft legislation on the changes within weeks.
+The legislation on the reforms will include other changes to the way the assembly works, including rules on disqualification of AMs and the design of the committee system.
+AMs will get the final vote on the question of what they should be called when they debate the legislation.
+Macedonians go to polls in referendum on changing country's name
+Voters will vote Sunday on whether to change their country's name to the "Republic of North Macedonia."
+The popular vote was set up in a bid to resolve a decades-long dispute with neighboring Greece, which has its own province called Macedonia.
+Athens has long insisted that its northern neighbor's name represents a claim on its territory and has repeatedly objected to its membership bids for the EU and NATO.
+Macedonian President Gjorge Ivanov, an opponent of the plebiscite on the name change, has said he will disregard the vote.
+However, supporters of the referendum, including Prime Minister Zoran Zaev, argue that the name change is simply the price to pay to join the EU and NATO.
+The Bells of St. Martin's Fall Silent as Churches in Harlem Struggle
+"Historically, the old people I've talked to say there was a bar and a church on every corner," Mr. Adams said.
+"Today, there's neither."
+He said the disappearance of bars was understandable.
+"People socialize in a different way" nowadays, he said.
+"Bars are no longer neighborhood living rooms where people go on a regular basis."
+As for churches, he worries that the money from selling assets will not last as long as leaders expect it to, "and sooner or later they'll be right back where they started."
+Churches, he added, could be replaced by apartment buildings with condominiums filled with the kind of people who will not help the neighborhood's remaining sanctuaries.
+"The overwhelming majority of people who buy condominiums in these buildings will be white," he said, "and therefore will hasten the day that these churches close altogether because it is unlikely that most of these people who move into these condominiums will become members of these churches."
+Both churches were built by white congregations before Harlem became a black metropolis - Metropolitan Community in 1870, St. Martin's a decade later.
+The original white Methodist congregation moved out in the 1930s.
+A black congregation that had been worshiping nearby took title to the building.
+St. Martin's was taken over by a black congregation under the Rev. John Howard Johnson, who led a boycott of retailers on 125th Street, a main street for shopping in Harlem, who resisted hiring or promoting blacks.
+A fire in 1939 left the building badly damaged, but as Father Johnson's parishioners made plans to rebuild, they commissioned the carillon.
+The Rev. David Johnson, Father Johnson's son and successor at St. Martin's, proudly called the carillon "the poor people's bells."
+The expert who played the carillon in July called it something else: "A cultural treasure" and "an irreplaceable historical instrument."
+The expert, Tiffany Ng of the University of Michigan, also noted that it was the first carillon in the world to be played by a black musician, Dionisio A. Lind, who moved to the larger carillon at the Riverside Church 18 years ago.
+Mr. Merriweather said that St. Martin's did not replace him.
+What has played out at St. Martin's over the last few months has been a complicated tale of architects and contractors, some brought in by the lay leaders of the church, others by the Episcopal diocese.
+The vestry - the parish's governing body, made up of lay leaders - wrote the diocese in July with concerns that the diocese "would seek to pass along the costs" to the vestry, even though the vestry had not been involved in hiring the architects and contractors the diocese sent in.
+Some parishioners complained of a lack of transparency on the diocese's part.
+Shark injures 13-year-old on lobster dive in California
+A shark attacked and injured a 13-year-old boy Saturday while he was diving for lobster in California on the opening day of lobster season, officials said.
+The attack occurred just before 7 a.m. near Beacon's Beach in Encinitas.
+Chad Hammel told KSWB-TV in San Diego he had been diving with friends for about half an hour Saturday morning when he heard the boy screaming for help and then paddled over with a group to help pull him out of the water.
+Hammel said at first he thought it was just excitement of catching a lobster, but then he "realized that he was yelling, 'I got bit!
+I got bit!'
+His whole clavicle was ripped open," Hammel said he noticed once he got to the boy.
+"I yelled at everyone to get out of the water: 'There's a shark in the water!'" Hammel added.
+The boy was airlifted to Rady Children's Hospital in San Diego where he is listed in critical condition.
+The species of shark responsible for the attack was unknown.
+Lifeguard Capt. Larry Giles said at a media briefing that a shark had been spotted in the area a few weeks earlier, but it was determined not to be a dangerous species of shark.
+Giles added the victim sustained traumatic injuries to his upper torso area.
+Officials shut down beach access from Ponto Beach in Casablad to Swami's in Ecinitas for 48 hours for investigation and safety purposes.
+Giles noted that there are more than 135 shark species in the area, but most are not considered dangerous.
+Sainsbury's plans push into UK beauty market
+Sainsbury's is taking on Boots, Superdrug and Debenhams with department store-style beauty aisles staffed with specialist assistants.
+As part of a substantial push into the UK's £2.8bn beauty market, which is continuing to grow while fashion and homeware sales fall back, the larger beauty aisles will be tested out in 11 stores around the country and taken to more stores next year if it proves a success.
+The investment in beauty comes as supermarkets hunt for ways to use up shelf space once sued for TVs, microwaves and homeware.
+Sainsbury's said it would be doubling the size of its beauty offering to up to 3,000 products, including brands such as Revlon, Essie, Tweezerman and Dr. PawPaw for the first time.
+Existing ranges from L'Oreal, Maybelline and Burt's Bees will also get more space with branded areas similar to those found in shops like Boots.
+The supermarket is also relaunching its Boutique makeup range so that the majority of products are vegan-friendly - something increasingly demanded by younger shoppers.
+In addition, perfume retailer the Fragrance Shop will be testing out concessions in two Sainsbury's stores, the first of which opened in Croydon, south London, last week while a second opens in Selly Oak, Birmingham, later this year.
+Online shopping and a shift towards buying small amounts of food daily at local convenience stores means supermarkets are having to do more to persuade people to visit.
+Mike Coupe, the chief executive of Sainsbury's, has said the outlets will look increasingly like department stores as the supermarket chain tries to fight back against the discounters Aldi and Lidl with more services and non-food.
+Sainsbury's has been putting Argos outlets in hundreds of stores and has also introduced a number of Habitats since it bought both chains two years ago, which it says has bolstered grocery sales and made the acquisitions more profitable.
+The supermarket's previous attempt to revamp its beauty and pharmacy departments ended in failure.
+Sainsbury's tested a joint venture with Boots in the early 2000s, but the tie-up ended after a row over how to split the revenues from the chemist's stores in its supermarkets.
+The new strategy comes after Sainsbury's sold its 281-store pharmacy business to Celesio, the owner of the Lloyds Pharmacy chain, for £125m, three years ago.
+It said Lloyds would play a role in the plan, by adding an extended range of luxury skincare brands including La Roche-Posay and Vichy in four stores.
+Paul Mills-Hicks, Sainsbury's commercial director, said: "We've transformed the look and feel of our beauty aisles to enhance the environment for our customers.
+We've also invested in specially trained colleagues who will be on hand to offer advice.
+Our range of brands is designed to suit every need and the alluring environment and convenient locations mean we're now a compelling beauty destination which challenges the old way of shopping."

--- a/leaderboard/testdata/newstest2019.msft-WMT19-document-level.6808.en-de.txt
+++ b/leaderboard/testdata/newstest2019.msft-WMT19-document-level.6808.en-de.txt
@@ -1,0 +1,75 @@
+Walisische AMs besorgt darüber, dass sie „wie Muppets aussehen“
+Einige AMs sind bestürzt über den Vorschlag, ihren Titel in MWPs (Mitglied des Walisischen Parlaments) zu ändern.
+Der Grund dafür sind Pläne, den Namen der Versammlung in das Walisische Parlament zu ändern.
+AMs aus dem gesamten politischen Spektrum sind besorgt, dass dies zu Spott führen könnte.
+Ein Labour-AM sagte, seine Fraktion sei besorgt darüber, dass „es sich mit Twp und Pwp reimt“.
+Für Leser außerhalb von Wales: Auf Walisisch bedeutet twp daft und pwp bedeutet poo.
+Ein Plaid-AM sagte, die Gruppe als Ganzes sei „nicht glücklich“ und habe Alternativen vorgeschlagen.
+Ein walisischer Konservativer sagte, seine Fraktion sei „aufgeschlossen“ gegenüber der Namensänderung, merkte jedoch an, dass es sich um einen kurzen verbalen Sprung von MWP zu Muppet handelte.
+In diesem Zusammenhang wird der walisische Buchstabe w ähnlich wie die Yorkshire-Englische Aussprache des Buchstabens u ausgesprochen.
+Die Versammlungskommission, die derzeit Rechtsvorschriften zur Einführung der Namensänderung ausarbeitet, sagte: „Die endgültige Entscheidung über die Bezeichnung der Mitglieder der Versammlung wird natürlich Sache der Mitglieder selbst sein“.
+Der Government of Wales Act 2017 gab der walisischen Versammlung die Befugnis, ihren Namen zu ändern.
+Im Juni veröffentlichte die Kommission die Ergebnisse einer öffentlichen Konsultation zu den Vorschlägen, die breite Unterstützung für die Bezeichnung der Versammlung als walisisches Parlament fand.
+In der Frage des Titels der AMs favorisierte die Kommission walisische Parlamentsmitglieder oder WMPs, aber die MWP-Option erhielt in einer öffentlichen Konsultation die meiste Unterstützung.
+Die AMs schlagen offenbar alternative Optionen vor, aber das Ringen um einen Konsens könnte dem Vorsitzenden, Elin Jones, Kopfzerbrechen bereiten, von dem erwartet wird, dass er innerhalb von Wochen einen Gesetzesentwurf zu den Änderungen vorlegt.
+Die Rechtsvorschriften zu den Reformen werden weitere Änderungen an der Arbeitsweise der Versammlung beinhalten, darunter Vorschriften über den Ausschluss von AMs und die Gestaltung des Ausschusssystems.
+Die AMs werden die Schlussabstimmung über die Frage erhalten, wie sie bei der Debatte über die Rechtsvorschriften genannt werden sollten.
+Mazedonier gehen bei Referendum über Namensänderung an die Urnen
+Die Wähler werden am Sonntag darüber abstimmen, ob sie den Namen ihres Landes in „Republik Nordmakedonien“ ändern wollen.
+Die Volksabstimmung wurde mit dem Ziel durchgeführt, einen jahrzehntelangen Streit mit dem Nachbarland Griechenland zu lösen, das eine eigene Provinz namens Mazedonien hat.
+Athen besteht seit langem darauf, dass der Name seines nördlichen Nachbarn einen Anspruch auf sein Territorium darstellt, und hat wiederholt Einspruch gegen seine Beitrittsgesuche für die EU und die NATO erhoben.
+Der mazedonische Präsident Gjorge Ivanov, ein Gegner der Volksabstimmung über die Namensänderung, hat erklärt, er werde die Abstimmung missachten.
+Die Befürworter des Referendums, darunter Ministerpräsident Zoran Zaev, argumentieren jedoch, dass die Namensänderung einfach der Preis sei, den man zahlen müsse, um der EU und der NATO beizutreten.
+Die Glocken von St. Martin verstummen, während die Kirchen in Harlem kämpfen
+„Historisch gesehen sagen die alten Leute, mit denen ich gesprochen habe, dass es an jeder Ecke eine Bar und eine Kirche gab“, sagte Mr. Adams.
+„Heute gibt es weder das eine noch das andere“.
+Er sagte, das Verschwinden der Bars sei verständlich.
+„Die Menschen sozialisieren sich heute auf eine andere Weise“, sagte er.
+„Bars sind keine Nachbarschaftswohnzimmer mehr, in die die Menschen regelmäßig gehen“.
+Was die Kirchen angeht, so sorgt er sich, dass das Geld aus dem Verkauf von Vermögenswerten nicht so lange halten wird, wie die Politiker es erwarten, „und früher oder später werden sie wieder da sein, wo sie angefangen haben“.
+Kirchen, fügte er hinzu, könnten durch Mehrfamilienhäuser mit Eigentumswohnungen ersetzt werden, die mit der Art von Menschen gefüllt sind, die den verbliebenen Heiligtümern der Nachbarschaft nicht helfen werden.
+„Die überwältigende Mehrheit der Menschen, die Eigentumswohnungen in diesen Gebäuden kaufen, werden weiß sein“, sagte er, „und werden daher den Tag beschleunigen, an dem diese Kirchen ganz geschlossen werden, weil es unwahrscheinlich ist, dass die meisten dieser Menschen, die in diese Eigentumswohnungen ziehen, Mitglieder dieser Kirchen werden“.
+Beide Kirchen wurden von weißen Gemeinden gebaut, bevor Harlem eine schwarze Metropole wurde – Metropolitan Community 1870, St. Martin's ein Jahrzehnt später.
+Die ursprüngliche weiße methodistische Gemeinde zog in den 1930er Jahren aus.
+Eine schwarze Gemeinde, die in der Nähe angebetet hatte, übernahm den Titel des Gebäudes.
+St. Martin's wurde von einer schwarzen Gemeinde unter Rev. John Howard Johnson übernommen, der einen Boykott von Einzelhändlern in der 125th Street, einer Haupteinkaufsstraße in Harlem, anführte, die sich weigerten, Schwarze einzustellen oder zu fördern.
+Ein Brand im Jahr 1939 hat das Gebäude schwer beschädigt, aber als die Gemeindemitglieder von Pater Johnson Pläne zum Wiederaufbau machten, beauftragten sie das Glockenspiel.
+Rev. David Johnson, Pater Johnsons Sohn und Nachfolger bei St. Martin's, nannte das Glockenspiel stolz „die Glocken der Armen“.
+Der Experte, der das Glockenspiel im Juli spielte, nannte es etwas anderes: „Ein kultureller Schatz“ und „ein unersetzliches historisches Instrument“.
+Der Experte, Tiffany Ng von der University of Michigan, merkte auch an, dass es das erste Glockenspiel der Welt war, das von einem schwarzen Musiker gespielt wurde, Dionisio A. Lind, der vor 18 Jahren in das größere Glockenspiel in der Riverside Church umzog.
+Mr. Merriweather sagte, dass St. Martin's ihn nicht ersetzte.
+Was sich in St. Martin's in den letzten Monaten abgespielt hat, war eine komplizierte Geschichte von Architekten und Auftragnehmern, einige von den Laienführern der Kirche, andere von der Bischofsdiözese.
+Die Sakristei – das Leitungsgremium der Pfarrei, das aus Laienführern besteht – schrieb die Diözese im Juli mit der Sorge, dass die Diözese versuchen würde, „die Kosten“ an die Sakristei weiterzugeben, obwohl die Sakristei nicht an der Einstellung der Architekten und Auftragnehmer beteiligt war, die von der Diözese entsandt wurden.
+Einige Gemeindemitglieder beschwerten sich über einen Mangel an Transparenz auf Seiten der Diözese.
+Hai verletzt 13-Jährigen beim Hummertauchen in Kalifornien
+Ein Hai hat am Samstag einen 13-jährigen Jungen beim Hummertauchen in Kalifornien am Eröffnungstag der Hummersaison angegriffen und verletzt, sagten Beamte.
+Der Angriff ereignete sich kurz vor 7 Uhr morgens in der Nähe von Beacon's Beach in Encinitas.
+Chad Hammel erzählte KSWB-TV in San Diego, dass er am Samstagmorgen etwa eine halbe Stunde lang mit Freunden getaucht sei, als er den Jungen um Hilfe schreien hörte und dann mit einer Gruppe paddelte, um ihn aus dem Wasser zu ziehen.
+Hammel sagte zunächst, dass er dachte, es sei nur Aufregung, einen Hummer zu fangen, aber dann „erkennte er, dass er schrie: 'Ich habe Biss!
+Ich habe Biss!'
+Sein ganzes Schlüsselbein wurde aufgerissen“, sagte Hammel, als er zu dem Jungen kam.
+„Ich schrie alle an, um aus dem Wasser zu kommen: 'Da ist ein Hai im Wasser!'“ fügte Hammel hinzu.
+Der Junge wurde in das Rady Children's Hospital in San Diego gebracht, wo er in einem kritischen Zustand ist.
+Die für den Angriff verantwortliche Haiart war unbekannt.
+Rettungsschwimmer Capt. Larry Giles sagte bei einem Medienbriefing, dass ein Hai in dem Gebiet einige Wochen zuvor gesichtet worden war, aber es wurde festgestellt, dass es sich nicht um eine gefährliche Haiart handelt.
+Giles fügte hinzu, dass das Opfer traumatische Verletzungen an seinem Oberkörperbereich erlitt.
+Die Beamten sperrten den Zugang zum Strand von Ponto Beach in Casablad nach Swami's in Ecinitas für 48 Stunden zu Untersuchungs- und Sicherheitszwecken.
+Giles stellte fest, dass es mehr als 135 Haiarten in dem Gebiet gibt, aber die meisten gelten nicht als gefährlich.
+Sainsbury's plant Vorstoß in den britischen Beauty-Markt
+Sainsbury's übernimmt Boots, Superdrug und Debenhams mit Beauty-Gängen im Kaufhausstil, die mit spezialisierten Assistenten besetzt sind.
+Als Teil eines erheblichen Vorstoßes in den britischen Beauty-Markt im Wert von 2,8 Mrd. GBP, der weiter wächst, während die Mode- und Haushaltswarenverkäufe zurückgehen, werden die größeren Beauty-Gänge in 11 Geschäften im ganzen Land getestet und im nächsten Jahr in weitere Läden gebracht, wenn sich dies als Erfolg erweist.
+Die Investition in Beauty kommt, während Supermärkte nach Möglichkeiten suchen, Regalflächen aufzubrauchen, die einst für Fernseher, Mikrowellen und Haushaltswaren verklagt wurden.
+Sainsbury's erklärte, es werde die Größe seines Beauty-Angebots auf bis zu 3.000 Produkte verdoppeln, darunter zum ersten Mal Marken wie Revlon, Essie, Tweezerman und Dr. PawPaw.
+Bestehende Sortimente von L'Oreal, Maybelline und Burt's Bees werden auch mehr Platz mit Markenbereichen erhalten, die denen in Geschäften wie Boots ähneln.
+Der Supermarkt bringt auch sein Boutique-Make-up-Sortiment neu auf den Markt, so dass die Mehrheit der Produkte vegan-freundlich ist – etwas, das von jüngeren Käufern zunehmend verlangt wird.
+Darüber hinaus wird der Parfümhändler Fragrance Shop Konzessionen in zwei Sainsbury's-Geschäften testen, von denen das erste letzte Woche in Croydon, Südlondon, eröffnet wurde, während ein zweites Ende dieses Jahres in Selly Oak, Birmingham, eröffnet wird.
+Online-Shopping und eine Verlagerung hin zum täglichen Einkauf kleiner Mengen von Lebensmitteln in lokalen Convenience-Stores bedeutet, dass Supermärkte mehr tun müssen, um die Menschen zum Besuch zu bewegen.
+Mike Coupe, der Geschäftsführer von Sainsbury's, sagte, dass die Verkaufsstellen zunehmend wie Kaufhäuser aussehen werden, da die Supermarktkette versucht, sich gegen die Discounter Aldi und Lidl mit mehr Dienstleistungen und Non-Food zu wehren.
+Sainsbury's hat Argos-Geschäfte in hunderten von Geschäften eingerichtet und auch eine Reihe von Habitats eingeführt, seit es vor zwei Jahren beide Ketten gekauft hat, was, wie es heißt, die Lebensmittelverkäufe gestärkt und die Akquisitionen profitabler gemacht hat.
+Der frühere Versuch des Supermarktes, seine Beauty- und Apothekenabteilungen umzugestalten, scheiterte.
+Sainsbury's testete Anfang der 2000er Jahre ein Joint Venture mit Boots, aber die Bindung endete nach einem Streit darüber, wie die Einnahmen aus den Apothekengeschäften in seinen Supermärkten aufgeteilt werden sollten.
+Die neue Strategie kommt, nachdem Sainsbury's vor drei Jahren sein 281-Store-Apothekengeschäft an Celesio, den Eigentümer der Lloyds Pharmacy-Kette, für 125 Mio. GBP verkaufte.
+Es hieß, dass Lloyds eine Rolle in dem Plan spielen würde, indem es eine erweiterte Palette von Luxus-Hautpflegemarken einschließlich La Roche-Posay und Vichy in vier Geschäften hinzufügte.
+Paul Mills-Hicks, der kaufmännische Direktor von Sainsbury's, sagte: „Wir haben das Aussehen und das Gefühl unserer Beauty-Gänge verändert, um das Umfeld für unsere Kunden zu verbessern.
+Wir haben auch in speziell ausgebildete Kollegen investiert, die zur Verfügung stehen werden, um Ratschläge zu erteilen.
+Unsere Markenpalette ist für jeden Bedarf ausgelegt, und die verlockende Umgebung und die günstigen Lagen bedeuten, dass wir jetzt ein überzeugendes Beauty-Reiseziel sind, das die alte Art des Einkaufens herausfordert“.

--- a/leaderboard/testdata/newstest2019.msft-WMT19-sentence-level.6785.en-de.txt
+++ b/leaderboard/testdata/newstest2019.msft-WMT19-sentence-level.6785.en-de.txt
@@ -1,0 +1,75 @@
+Welsh AMs besorgt über 'aussehen wie Muppets'
+Es gibt Bestürzung unter einigen AMs über einen Vorschlag, ihren Titel in MWPs (Mitglied des walisischen Parlaments) zu ändern.
+Es ist aufgrund von Plänen entstanden, den Namen der Versammlung in das walisische Parlament zu ändern.
+AMs aus dem gesamten politischen Spektrum sind besorgt, dass es zum Spott einladen könnte.
+Ein Labour AM sagte, seine Gruppe sei besorgt, „es reimt sich mit Twp und Pwp“.
+Für Leser außerhalb von Wales: In Walisisch bedeutet twp daft und pwp poo.
+Ein Plaid AM sagte, die Gruppe als Ganzes sei „nicht glücklich“ und habe Alternativen vorgeschlagen.
+Ein walisischer Konservativer sagte, seine Fraktion sei „offen“ über die Namensänderung, merkte aber an, dass es ein kurzer verbaler Sprung von MWP zu Muppet war.
+In diesem Zusammenhang wird der walisische Buchstabe w ähnlich wie die Yorkshire-englische Aussprache des Buchstabens u ausgesprochen.
+Die Vollversammlungskommission, die derzeit ein Gesetz zur Einführung der Namensänderungen ausarbeitet, sagte: „Die endgültige Entscheidung über alle Deskriptoren dessen, was Vollversammlungsmitglieder genannt werden, wird selbstverständlich eine Angelegenheit der Mitglieder selbst sein“.
+Der Government of Wales Act 2017 gab der walisischen Versammlung die Befugnis, ihren Namen zu ändern.
+Im Juni veröffentlichte die Kommission die Ergebnisse einer öffentlichen Konsultation zu den Vorschlägen, die breite Unterstützung für die Einberufung der Versammlung in ein walisisches Parlament fanden.
+Was den Titel der AM betrifft, so bevorzugte die Kommission walisische Parlamentsabgeordnete oder WMPs, aber die MWP-Option erhielt in einer öffentlichen Konsultation die größte Unterstützung.
+AMs schlagen anscheinend alternative Optionen vor, aber das Ringen um einen Konsens könnte dem Vorsitzenden Elin Jones Kopfzerbrechen bereiten, der innerhalb von Wochen Gesetzesentwürfe zu den Änderungen vorlegen soll.
+Die Rechtsvorschriften zu den Reformen werden weitere Änderungen an der Arbeitsweise der Versammlung beinhalten, darunter Vorschriften über den Ausschluss von AMs und die Ausgestaltung des Ausschusssystems.
+AMs werden die Schlussabstimmung über die Frage erhalten, wie sie genannt werden sollten, wenn sie über die Rechtsvorschriften debattieren.
+Mazedonier gehen an die Urnen in Referendum über die Änderung des Namens des Landes
+Die Wähler werden am Sonntag darüber abstimmen, ob sie den Namen ihres Landes in „Republik Nordmakedonien“ ändern wollen.
+Die Volksabstimmung wurde ins Leben gerufen, um einen jahrzehntelangen Streit mit dem benachbarten Griechenland zu lösen, das eine eigene Provinz namens Mazedonien hat.
+Athen besteht seit langem darauf, dass der Name seines nördlichen Nachbarn einen Anspruch auf sein Territorium darstellt, und hat wiederholt Einwände gegen seine Beitrittsgesuche für die EU und die NATO erhoben.
+Der mazedonische Präsident Gjorge Ivanov, ein Gegner der Volksabstimmung über die Namensänderung, hat erklärt, er werde die Abstimmung missachten.
+Die Befürworter des Referendums, darunter Premierminister Zoran Zaev, argumentieren jedoch, dass die Namensänderung lediglich der Preis sei, den man für den Beitritt zur EU und zur NATO zahlen müsse.
+Die Glocken von St. Martins Fall schweigen als Kirchen in Harlem Kampf
+„Historisch gesehen haben die alten Leute, mit denen ich gesprochen habe, gesagt, dass es an jeder Ecke eine Bar und eine Kirche gab“, sagte Herr Adams.
+„Heute gibt es weder das eine noch das andere“.
+Er sagte, das Verschwinden von Bars sei verständlich.
+„Die Menschen sozialisieren sich heute auf eine andere Weise“, sagte er.
+„Bars sind keine Nachbarschafts-Wohnzimmer mehr, in die die Leute regelmäßig gehen“.
+Was die Kirchen angeht, so befürchtet er, dass das Geld aus dem Verkauf von Vermögenswerten nicht so lange reichen wird, wie die Führer es erwarten, „und früher oder später werden sie wieder da sein, wo sie angefangen haben“.
+Kirchen, fügte er hinzu, könnten durch Mehrfamilienhäuser mit Eigentumswohnungen ersetzt werden, die mit der Art von Menschen gefüllt sind, die den verbleibenden Heiligtümern des Viertels nicht helfen werden.
+„Die überwältigende Mehrheit der Menschen, die Eigentumswohnungen in diesen Gebäuden kaufen, wird weiß sein“, sagte er, „und wird daher den Tag beschleunigen, an dem diese Kirchen ganz schließen, weil es unwahrscheinlich ist, dass die meisten dieser Menschen, die in diese Eigentumswohnungen einziehen, Mitglieder dieser Kirchen werden“.
+Beide Kirchen wurden von weißen Gemeinden gebaut, bevor Harlem eine schwarze Metropole wurde – Metropolitan Community 1870, St. Martin's ein Jahrzehnt später.
+Die ursprüngliche weiße Methodisten-Gemeinde zog in den 1930er Jahren aus.
+Eine schwarze Gemeinde, die in der Nähe angebetet hatte, übernahm den Titel des Gebäudes.
+St. Martin's wurde von einer schwarzen Gemeinde unter Rev. John Howard Johnson übernommen, der einen Boykott von Einzelhändlern auf der 125th Street, einer Hauptstraße zum Einkaufen in Harlem, führte, die sich der Einstellung oder Förderung von Schwarzen widersetzten.
+Ein Brand im Jahre 1939 hinterließ das Gebäude schwer beschädigt, aber als Pfarrangehörige von Pater Johnson Pläne zum Wiederaufbau machten, gaben sie das Glockenspiel in Auftrag.
+Rev. David Johnson, Vater Johnsons Sohn und Nachfolger bei St. Martin, nannte das Glockenspiel stolz „die Glocken der armen Leute“.
+Der Experte, der das Carillon im Juli spielte, nannte es etwas anderes: „Ein Kulturschatz“ und „ein unersetzliches historisches Instrument“.
+Der Experte, Tiffany Ng von der University of Michigan, bemerkte auch, dass es das erste Carillon der Welt war, das von einem schwarzen Musiker, Dionisio A. Lind, gespielt wurde, der vor 18 Jahren in das größere Carillon an der Riverside Church umzog.
+Herr Merriweather sagte, dass St. Martin's ihn nicht ersetzt habe.
+Was sich in den letzten Monaten in St. Martin abgespielt hat, war eine komplizierte Geschichte von Architekten und Bauunternehmern, von denen einige von den Laienführern der Kirche, andere von der Bischofsdiözese eingebracht wurden.
+Die Sakristei – das Leitungsgremium der Pfarrei, das sich aus Laienführern zusammensetzt – schrieb der Diözese im Juli mit der Befürchtung, dass die Diözese versuchen würde, die Kosten auf die Sakristei abzuwälzen, obwohl die Sakristei nicht an der Einstellung der von der Diözese entsandten Architekten und Bauunternehmer beteiligt gewesen sei.
+Einige Gemeindemitglieder beklagten sich über mangelnde Transparenz seitens der Diözese.
+Hai verletzt 13-Jährigen bei Hummer-Tauchgang in Kalifornien
+Ein Hai angegriffen und verletzt einen 13-jährigen Jungen Samstag, während er für Hummer in Kalifornien am Eröffnungstag der Hummersaison tauchen, sagten Beamte.
+Der Angriff ereignete sich kurz vor 7 Uhr morgens in der Nähe von Beacon's Beach in Encinitas.
+Chad Hammel erzählte KSWB-TV in San Diego, dass er am Samstagmorgen etwa eine halbe Stunde mit Freunden getaucht war, als er den Jungen um Hilfe schreien hörte und dann mit einer Gruppe hinüberpaddelte, um ihn aus dem Wasser zu ziehen.
+Hammel sagte zunächst, er dachte, es sei nur Aufregung, einen Hummer zu fangen, aber dann „erkannte er, dass er schrie: 'Ich habe gebissen!
+Ich habe gebissen!'
+Sein ganzes Schlüsselbein war aufgerissen“, sagte Hammel, als er zu dem Jungen kam.
+„Ich schrie alle an, um aus dem Wasser zu kommen: 'Da ist ein Hai im Wasser!'“, fügte Hammel hinzu.
+Der Junge wurde ins Rady Children's Hospital in San Diego geflogen, wo er in kritischem Zustand gelistet ist.
+Die Haiart, die für den Angriff verantwortlich war, war unbekannt.
+Rettungsschwimmer Capt. Larry Giles sagte bei einem Medienbriefing, dass ein Hai in der Gegend ein paar Wochen zuvor gesichtet worden war, aber es wurde festgestellt, nicht eine gefährliche Haiart zu sein.
+Giles fügte hinzu, das Opfer erlitt traumatische Verletzungen an seinem oberen Oberkörperbereich.
+Beamte sperrten den Strandzugang von Ponto Beach in Casablad zu Swami's in Ecinitas für 48 Stunden für Ermittlungs- und Sicherheitszwecke.
+Giles darauf hingewiesen, dass es mehr als 135 Haiarten in der Gegend, aber die meisten sind nicht als gefährlich.
+Sainsburys Pläne drängen in den britischen Schönheitsmarkt
+Sainsbury's nimmt Boots, Superdrug und Debenhams mit Kaufhaus-Stil Schönheit Gänge mit spezialisierten Assistenten besetzt.
+Als Teil eines erheblichen Vorstoßes in den britischen Schönheitsmarkt mit einem Volumen von 2,8 Mrd. Pfund, der weiter wächst, während die Verkäufe von Mode und Haushaltswaren zurückgehen, werden die größeren Beauty-Gänge in 11 Geschäften im ganzen Land getestet und im nächsten Jahr in weitere Läden gebracht, wenn sich dies als Erfolg erweist.
+Die Investition in Schönheit kommt als Supermärkte Jagd nach Möglichkeiten, um bis Regalplatz einmal verklagt für TVs, Mikrowellen und Haushaltswaren zu verwenden.
+Sainsbury's sagte, es wäre die Verdoppelung der Größe seines Beauty-Angebot auf bis zu 3.000 Produkte, darunter Marken wie Revlon, Essie, Tweezerman und Dr. PawPaw zum ersten Mal.
+Bestehende Sortimente von L'Oreal, Maybelline und Burt's Bees erhalten ebenfalls mehr Platz mit Markenbereichen, die denen in Geschäften wie Boots ähneln.
+Zudem bringt der Supermarkt sein Boutique-Make-up-Sortiment neu auf den Markt, so dass die meisten Produkte vegan-freundlich sind – was zunehmend von jüngeren Käufern nachgefragt wird.
+Darüber hinaus wird der Parfümhändler Fragrance Shop Konzessionen in zwei Sainsbury's Stores testen, von denen der erste letzte Woche in Croydon, Süd-London, eröffnete, während ein zweiter in Selly Oak, Birmingham, später in diesem Jahr eröffnet.
+Online-Shopping und eine Verschiebung hin zum Kauf kleiner Mengen von Lebensmitteln täglich in lokalen Convenience-Stores bedeutet, Supermärkte müssen mehr tun, um die Menschen zu überzeugen, zu besuchen.
+Mike Coupe, der Vorstandsvorsitzende von Sainsbury's, hat gesagt, dass die Verkaufsstellen zunehmend wie Kaufhäuser aussehen werden, da die Supermarktkette versucht, sich mit mehr Dienstleistungen und Non-Food gegen die Discounter Aldi und Lidl zu wehren.
+Sainsbury's hat Argos-Filialen in Hunderten von Geschäften platziert und auch eine Reihe von Habitats eingeführt, seit es beide Ketten vor zwei Jahren gekauft hat, was, wie es sagt, die Lebensmittelverkäufe gestärkt und die Akquisitionen profitabler gemacht hat.
+Der frühere Versuch des Supermarktes, seine Schönheits- und Apothekenabteilungen umzugestalten, scheiterte.
+Sainsbury's testete ein Joint Venture mit Boots in den frühen 2000er Jahren, aber die Krawatte endete nach einem Streit darüber, wie man die Einnahmen aus den Apotheken in seinen Supermärkten zu teilen.
+Die neue Strategie kommt, nachdem Sainsbury's vor drei Jahren sein 281-Store-Apothekengeschäft für 125 Millionen Pfund an Celesio, den Eigentümer der Lloyds-Apothekenkette, verkauft hatte.
+Lloyds werde eine Rolle in dem Plan spielen, indem es eine erweiterte Palette von Luxus-Hautpflege-Marken wie La Roche-Posay und Vichy in vier Filialen hinzufüge.
+Paul Mills-Hicks, kaufmännischer Direktor von Sainsbury, sagte: „Wir haben das Aussehen und die Haptik unserer Beauty-Gänge verändert, um die Umwelt für unsere Kunden zu verbessern.
+Wir haben auch in speziell geschulte Kollegen investiert, die mit Rat und Tat zur Seite stehen.
+Unsere Markenpalette ist auf jeden Bedarf zugeschnitten und die verführerische Umgebung und die günstigen Lagen machen uns zu einem attraktiven Beauty-Destination, die die alte Art des Einkaufens herausfordert“.

--- a/leaderboard/testdata/newstest2019.msft-WMT19-sentence_document.6974.en-de.txt
+++ b/leaderboard/testdata/newstest2019.msft-WMT19-sentence_document.6974.en-de.txt
@@ -1,0 +1,75 @@
+Welsh AMs besorgt darüber, dass sie „wie Muppets aussehen“
+Unter einigen AMs herrscht Bestürzung über den Vorschlag, ihren Titel in MWPs (Mitglied des walisischen Parlaments) umzuändern.
+Er entstand aufgrund von Plänen, den Namen der Versammlung in das walisische Parlament umzuändern.
+AMs aus dem gesamten politischen Spektrum sind besorgt darüber, dass dies zu Spott führen könnte.
+Ein Labour AM sagte, seine Fraktion sei besorgt darüber, dass „es sich mit Twp und Pwp reimt“.
+Für Leser außerhalb von Wales: In Walisisch bedeutet twp daft und pwp bedeutet poo.
+Ein Plaid AM sagte, die Gruppe als Ganzes sei „nicht glücklich“ und habe Alternativen vorgeschlagen.
+Ein walisischer Konservativer sagte, seine Fraktion sei „offen“ über die Namensänderung, merkte aber an, dass es sich um einen kurzen verbalen Sprung von MWP zu Muppet handele.
+In diesem Zusammenhang wird der walisische Buchstabe w ähnlich wie die Yorkshire-englische Aussprache des Buchstabens u ausgesprochen.
+Die Versammlungskommission, die derzeit Rechtsvorschriften zur Einführung der Namensänderung ausarbeitet, sagte: „Die endgültige Entscheidung über alle Deskriptoren dessen, was Versammlungsmitglieder genannt werden, wird natürlich Sache der Mitglieder selbst sein“.
+Der Government of Wales Act 2017 gab der walisischen Versammlung die Befugnis, ihren Namen zu ändern.
+Im Juni veröffentlichte die Kommission die Ergebnisse einer öffentlichen Konsultation zu den Vorschlägen, die breite Unterstützung dafür fand, die Versammlung ein walisisches Parlament zu nennen.
+In der Frage des Titels der AMs bevorzugte die Kommission walisische Parlamentsmitglieder oder WMPs, aber die MWP-Option erhielt in einer öffentlichen Konsultation die meiste Unterstützung.
+AMs schlagen anscheinend alternative Optionen vor, aber das Ringen um einen Konsens könnte dem Vorsitzenden, Elin Jones, Kopfzerbrechen bereiten, von dem erwartet wird, dass er innerhalb von Wochen einen Gesetzesentwurf zu den Änderungen vorlegt.
+Die Rechtsvorschriften zu den Reformen werden weitere Änderungen an der Arbeitsweise der Versammlung beinhalten, darunter Vorschriften über den Ausschluss von AMs und die Gestaltung des Ausschusssystems.
+AMs werden die Schlussabstimmung über die Frage erhalten, wie sie bei der Erörterung der Rechtsvorschriften genannt werden sollten.
+Mazedonier gehen bei Referendum über Namensänderung an die Urnen
+Die Wähler werden am Sonntag darüber abstimmen, ob sie den Namen ihres Landes in „Republik Nordmakedonien“ ändern wollen.
+Die Volksabstimmung wurde ins Leben gerufen, um einen jahrzehntelangen Streit mit dem benachbarten Griechenland zu lösen, das eine eigene Provinz namens Mazedonien hat.
+Athen besteht seit langem darauf, dass der Name seines nördlichen Nachbarn einen Anspruch auf sein Territorium darstellt, und hat wiederholt Einwände gegen seine Beitrittsgesuche für die EU und die NATO erhoben.
+Der mazedonische Präsident Gjorge Ivanov, ein Gegner der Volksabstimmung über die Namensänderung, hat erklärt, dass er die Abstimmung missachten werde.
+Die Befürworter des Referendums, darunter Ministerpräsident Zoran Zaev, argumentieren jedoch, dass die Namensänderung einfach der Preis sei, den man zahlen müsse, um der EU und der NATO beizutreten.
+Die Glocken des St. Martin's Fall Silent als Kirchen in Harlem Kampf
+„Historisch gesehen sagen die alten Leute, mit denen ich gesprochen habe, dass es an jeder Ecke eine Bar und eine Kirche gab“, sagte Herr Adams.
+„Heute gibt es weder das eine noch das andere“.
+Er sagte, das Verschwinden der Bars sei verständlich.
+„Die Menschen sozialisieren sich heute auf eine andere Weise“, sagte er.
+„Bars sind keine Nachbarschaftswohnzimmer mehr, in die die Menschen regelmäßig gehen“.
+Was die Kirchen angeht, so sorgt er sich, dass das Geld aus dem Verkauf von Vermögenswerten nicht so lange halten wird, wie die Führer es erwarten, „und früher oder später werden sie wieder da sein, wo sie angefangen haben“.
+Kirchen, fügte er hinzu, könnten durch Mehrfamilienhäuser mit Eigentumswohnungen ersetzt werden, die mit der Art von Menschen gefüllt sind, die den verbliebenen Heiligtümern der Nachbarschaft nicht helfen werden.
+„Die überwältigende Mehrheit der Menschen, die Eigentumswohnungen in diesen Gebäuden kaufen, wird weiß sein“, sagte er, „und wird daher den Tag beschleunigen, an dem diese Kirchen ganz geschlossen werden, weil es unwahrscheinlich ist, dass die meisten dieser Menschen, die in diese Eigentumswohnungen ziehen, Mitglieder dieser Kirchen werden“.
+Beide Kirchen wurden von weißen Gemeinden gebaut, bevor Harlem eine schwarze Metropole wurde – Metropolitan Community 1870, St. Martin's ein Jahrzehnt später.
+Die ursprüngliche weiße Methodistengemeinde zog in den 1930er Jahren aus.
+Eine schwarze Gemeinde, die in der Nähe angebetet hatte, übernahm den Titel des Gebäudes.
+St. Martin's wurde von einer schwarzen Gemeinde unter Rev. John Howard Johnson übernommen, der einen Boykott von Einzelhändlern an der 125th Street, einer Haupteinkaufsstraße in Harlem, anführte, die sich weigerten, Schwarze einzustellen oder zu fördern.
+Ein Brand im Jahr 1939 hinterließ das Gebäude schwer beschädigt, aber als die Gemeindemitglieder von Pater Johnson Pläne zum Wiederaufbau machten, gaben sie das Carillon in Auftrag.
+Rev. David Johnson, Pater Johnsons Sohn und Nachfolger bei St. Martin's, nannte das Carillon stolz „die Glocken der Armen“.
+Der Experte, der das Carillon im Juli spielte, nannte es etwas anderes: „Ein kultureller Schatz“ und „ein unersetzliches historisches Instrument“.
+Der Experte, Tiffany Ng von der University of Michigan, bemerkte auch, dass es das erste Carillon der Welt war, das von einem schwarzen Musiker gespielt wurde, Dionisio A. Lind, der vor 18 Jahren in das größere Carillon an der Riverside Church umzog.
+Herr Merriweather sagte, dass St. Martin's ihn nicht ersetzt habe.
+Was sich in den letzten Monaten in St. Martin's abgespielt hat, war eine komplizierte Geschichte von Architekten und Bauunternehmern, von denen einige von den Laienführern der Kirche, andere von der Bischofsdiözese eingebracht wurden.
+Die Sakristei – das Leitungsgremium der Pfarrei, das sich aus Laienführern zusammensetzt – schrieb die Diözese im Juli mit der Sorge, dass die Diözese versuchen würde, die Kosten auf die Sakristei abzuwälzen, obwohl die Sakristei nicht an der Einstellung der Architekten und Bauunternehmer beteiligt war, die von der Diözese entsandt wurden.
+Einige Gemeindemitglieder beschwerten sich über einen Mangel an Transparenz seitens der Diözese.
+Hai verletzt 13-Jährigen bei Hummer-Tauchgang in Kalifornien
+Ein Hai hat am Samstag einen 13-jährigen Jungen angegriffen und verletzt, als er am Eröffnungstag der Hummersaison in Kalifornien nach Hummer taumelte, sagten Beamte.
+Der Angriff ereignete sich kurz vor 7 Uhr morgens in der Nähe von Beacon's Beach in Encinitas.
+Chad Hammel erzählte KSWB-TV in San Diego, dass er am Samstagmorgen etwa eine halbe Stunde lang mit Freunden getaucht war, als er den Jungen um Hilfe schreien hörte und dann mit einer Gruppe hinüberpaddelte, um ihn aus dem Wasser zu ziehen.
+Hammel sagte zunächst, er dachte, es sei nur Aufregung, einen Hummer zu fangen, aber dann „erkannte er, dass er schrie: 'Ich habe gebissen!
+Ich habe gebissen!'
+Sein ganzes Schlüsselbein wurde aufgerissen“, sagte Hammel, als er zu dem Jungen kam.
+„Ich schrie jeden an, um aus dem Wasser zu kommen: 'Da ist ein Hai im Wasser!'“, fügte Hammel hinzu.
+Der Junge wurde in das Rady Children's Hospital in San Diego gebracht, wo er in einem kritischen Zustand ist.
+Die für den Angriff verantwortliche Haiart war unbekannt.
+Rettungsschwimmer Capt. Larry Giles sagte bei einem Medienbriefing, dass ein Hai in dem Gebiet einige Wochen zuvor gesichtet worden war, aber es wurde festgestellt, dass es sich nicht um eine gefährliche Haiart handelt.
+Giles fügte hinzu, dass das Opfer traumatische Verletzungen an seinem Oberkörperbereich erlitt.
+Beamte sperrten den Strandzugang von Ponto Beach in Casablad zu Swami's in Ecinitas für 48 Stunden zu Untersuchungs- und Sicherheitszwecken.
+Giles stellte fest, dass es mehr als 135 Haiarten in dem Gebiet gibt, aber die meisten gelten nicht als gefährlich.
+Sainsbury's plant Vorstoß in den britischen Schönheitsmarkt
+Sainsbury's übernimmt Boots, Superdrug und Debenhams mit Beauty-Gängen im Kaufhausstil, die mit spezialisierten Assistenten besetzt sind.
+Als Teil eines erheblichen Vorstoßes in den britischen Schönheitsmarkt mit einem Volumen von 2,8 Mrd. GBP, der weiter wächst, während Mode- und Haushaltswarenverkäufe zurückgehen, werden die größeren Beauty-Gänge in 11 Geschäften im ganzen Land getestet und im nächsten Jahr in weitere Läden gebracht, wenn sich dies als Erfolg erweist.
+Die Investition in Schönheit kommt, während Supermärkte nach Möglichkeiten suchen, Regalflächen zu nutzen, die einst für Fernseher, Mikrowellen und Haushaltswaren verklagt wurden.
+Sainsbury's erklärte, es werde die Größe seines Beauty-Angebots auf bis zu 3.000 Produkte verdoppeln, darunter zum ersten Mal Marken wie Revlon, Essie, Tweezerman und Dr. PawPaw.
+Bestehende Sortimente von L'Oreal, Maybelline und Burt's Bees werden ebenfalls mehr Platz mit Markenbereichen erhalten, die denen in Geschäften wie Boots ähneln.
+Der Supermarkt bringt auch sein Boutique-Make-up-Sortiment neu auf den Markt, so dass die Mehrheit der Produkte vegan-freundlich ist – etwas, das zunehmend von jüngeren Käufern verlangt wird.
+Darüber hinaus wird der Parfümhändler Fragrance Shop Konzessionen in zwei Sainsbury's-Geschäften testen, von denen das erste letzte Woche in Croydon, Süd-London, eröffnet wurde, während ein zweites im Laufe dieses Jahres in Selly Oak, Birmingham, eröffnet wird.
+Online-Shopping und eine Verlagerung hin zum täglichen Kauf kleiner Mengen von Lebensmitteln in lokalen Convenience-Stores bedeutet, dass Supermärkte mehr tun müssen, um die Menschen zum Besuch zu überreden.
+Mike Coupe, der Vorstandsvorsitzende von Sainsbury's, sagte, dass die Verkaufsstellen zunehmend wie Kaufhäuser aussehen werden, da die Supermarktkette versucht, sich gegen die Discounter Aldi und Lidl mit mehr Dienstleistungen und Non-Food zu wehren.
+Sainsbury's hat Argos-Geschäfte in Hunderten von Geschäften eingerichtet und auch eine Reihe von Habitats eingeführt, seit es vor zwei Jahren beide Ketten gekauft hat, was, wie es heißt, die Lebensmittelverkäufe gestärkt und die Akquisitionen profitabler gemacht hat.
+Der frühere Versuch des Supermarktes, seine Beauty- und Apothekenabteilungen umzugestalten, scheiterte.
+Sainsbury's testete Anfang der 2000er Jahre ein Joint Venture mit Boots, aber die Bindung endete nach einem Streit darüber, wie man die Einnahmen aus den Apothekengeschäften in seinen Supermärkten aufteilt.
+Die neue Strategie kommt, nachdem Sainsbury's vor drei Jahren sein 281-Store-Apothekengeschäft an Celesio, den Eigentümer der Lloyds-Apothekenkette, für 125 Mio. GBP verkauft hat.
+Es hieß, dass Lloyds eine Rolle in dem Plan spielen würde, indem es eine erweiterte Palette von Luxus-Hautpflegemarken, darunter La Roche-Posay und Vichy, in vier Geschäften hinzufügt.
+Paul Mills-Hicks, der kaufmännische Direktor von Sainsbury, sagte: „Wir haben das Aussehen und das Gefühl unserer Beauty-Gänge verändert, um das Umfeld für unsere Kunden zu verbessern.
+Wir haben auch in speziell ausgebildete Kollegen investiert, die zur Verfügung stehen werden, um Ratschläge zu geben.
+Unsere Markenpalette ist so konzipiert, dass sie auf jeden Bedarf zugeschnitten ist, und die verführerische Umgebung und die günstigen Lagen bedeuten, dass wir jetzt ein überzeugendes Beauty-Ziel sind, das die alte Art des Einkaufens herausfordert“.

--- a/leaderboard/tests.py
+++ b/leaderboard/tests.py
@@ -2,30 +2,92 @@
 Project OCELoT: Open, Competitive Evaluation Leaderboard of Translations
 """
 from datetime import datetime
-from json import loads
-from pathlib import Path
+import os
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
+from ocelot.settings import BASE_DIR
+
 from leaderboard.models import Competition
+from leaderboard.models import Language
+from leaderboard.models import SGML_FILE
+from leaderboard.models import Submission
+from leaderboard.models import Team
 from leaderboard.models import TestSet
+from leaderboard.models import TEXT_FILE
+
+TESTDATA_DIR = os.path.join(BASE_DIR, 'leaderboard/testdata')
 
 
 class LeaderboardTests(TestCase):
     """Tests leaderboard app."""
 
     def setUp(self):
-        Competition.objects.create(
-            name='Competition no. 1',
-            description='Description of the competition no. 1',
-            deadline=datetime(2021, 1, 1, 12, 30, tzinfo=timezone.utc),
+        l_en = Language.objects.create(code='en', name='English')
+        l_de = Language.objects.create(code='de', name='German')
+
+        _next_year = datetime.now().year + 1
+        c1 = Competition.objects.create(
+            name='Competition A',
+            description='Description of the competition A',
+            deadline=datetime(_next_year, 1, 1, tzinfo=timezone.utc),
         )
+
+        ts1 = TestSet.objects.create(
+            is_active=True,
+            name='TestSet A',
+            source_language=l_en,
+            target_language=l_de,
+            file_format=SGML_FILE,
+            src_file=os.path.join(
+                TESTDATA_DIR, 'newstest2019-ende-src.en.sgm'
+            ),
+            ref_file=os.path.join(
+                TESTDATA_DIR, 'newstest2019-ende-ref.de.sgm'
+            ),
+        )
+        c1.test_sets.add(ts1)
+
+        t1 = Team.objects.create(
+            is_active=True,
+            name='Team A',
+            email='team-a@email.com',
+            token='a111111111',
+        )
+
+        _file1 = 'newstest2019.msft-WMT19-document-level.6808.en-de.txt'
+        Submission.objects.create(
+            name=_file1,
+            original_name=_file1,
+            test_set=ts1,
+            submitted_by=t1,
+            file_format=TEXT_FILE,
+            hyp_file=os.path.join(TESTDATA_DIR, _file1),
+        )
+
+        t2 = Team.objects.create(
+            is_active=True,
+            name='Team B',
+            email='team-b@email.com',
+            token='b111111111',
+        )
+
+        _file2 = 'newstest2019.msft-WMT19-sentence-level.6785.en-de.txt'
+        Submission.objects.create(
+            name=_file2,
+            original_name=_file2,
+            test_set=ts1,
+            submitted_by=t2,
+            file_format=TEXT_FILE,
+            hyp_file=os.path.join(TESTDATA_DIR, _file2),
+        )
+
         Competition.objects.create(
-            name='Competition no. 2',
-            description='Description of the competition no. 2',
-            deadline=datetime(2021, 1, 2, 12, 30, tzinfo=timezone.utc),
+            name='Competition B',
+            description='Description of the competition B',
+            deadline=datetime(_next_year, 1, 12, tzinfo=timezone.utc),
         )
 
     def test_frontpage_renders_correctly(self):
@@ -36,15 +98,15 @@ class LeaderboardTests(TestCase):
     def test_frontpage_knows_about_competitions(self):
         """Checks that frontpage retrieve list of competitions."""
         response = self.client.get('/')
-        self.assertContains(response, 'Competition no. 1')
-        self.assertContains(response, 'Competition no. 2')
+        self.assertContains(response, 'Competition A')
+        self.assertContains(response, 'Competition B')
 
     def test_leaderboard_renders_correctly_if_competition_exists(self):
         """Checks that leaderboard/<existing-id> renders correctly."""
         comp = Competition.objects.all().first()
         response = self.client.get('/leaderboard/{0}'.format(comp.id))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Competition no. 1')
+        self.assertContains(response, comp.name)
 
     def test_leaderboard_renders_404_if_competition_does_not_exist(self):
         """Checks that leaderboard/<non-existing-id> renders 404."""

--- a/leaderboard/tests.py
+++ b/leaderboard/tests.py
@@ -191,3 +191,26 @@ class LeaderboardTests(TestCase):
         """Checks that leaderboard/<non-existing-id> renders 404."""
         response = self.client.get('/leaderboard/1234')
         self.assertEqual(response.status_code, 404)
+
+    def test_leaderboard_shows_competition_description(self):
+        """Checks that leaderboard contains description of the competition."""
+        comp = Competition.objects.get(name='Competition A')
+        response = self.client.get('/leaderboard/{0}'.format(comp.id))
+        self.assertContains(response, comp.description)
+
+    def test_leaderboard_without_submissions(self):
+        """Checks that leaderboard without submissions shows no submissions."""
+        comp = Competition.objects.get(name='Competition B')
+        response = self.client.get('/leaderboard/{0}'.format(comp.id))
+        self.assertNotContains(response, 'Anonymous submission #')
+        self.assertContains(response, 'No submissions')
+
+    def test_leaderboard_with_submissions(self):
+        """Checks that leaderboard with submissions shows submissions."""
+        comp = Competition.objects.get(name='Competition A')
+        response = self.client.get('/leaderboard/{0}'.format(comp.id))
+        # Get all submissions to this campaign
+        subs = Submission.objects.filter(test_set__leaderboard_competition=comp.id)
+        for sub in subs:
+            self.assertContains(response, str(sub))
+        self.assertNotContains(response, 'No submissions')

--- a/leaderboard/tests.py
+++ b/leaderboard/tests.py
@@ -1,14 +1,11 @@
 """
 Project OCELoT: Open, Competitive Evaluation Leaderboard of Translations
 """
-from datetime import datetime
 import os
+from datetime import datetime
 
-from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
-
-from ocelot.settings import BASE_DIR
 
 from leaderboard.models import Competition
 from leaderboard.models import Language
@@ -17,6 +14,7 @@ from leaderboard.models import Submission
 from leaderboard.models import Team
 from leaderboard.models import TestSet
 from leaderboard.models import TEXT_FILE
+from ocelot.settings import BASE_DIR
 
 TESTDATA_DIR = os.path.join(BASE_DIR, 'leaderboard/testdata')
 
@@ -80,10 +78,10 @@ class TestSetTests(TestCase):
             ),
         )
 
-        ts = TestSet.objects.get(name='TestSetA')
-        self.assertEqual(ts.name, 'TestSetA')
-        self.assertTrue(ts.src_file.name.endswith('.sgm'))
-        self.assertTrue(ts.ref_file.name.endswith('.sgm'))
+        tst = TestSet.objects.get(name='TestSetA')
+        self.assertEqual(tst.name, 'TestSetA')
+        self.assertTrue(tst.src_file.name.endswith('.sgm'))
+        self.assertTrue(tst.ref_file.name.endswith('.sgm'))
 
     def test_create_test_set_with_text_files(self):
         """Checks that a test set can be created from text files."""
@@ -98,10 +96,10 @@ class TestSetTests(TestCase):
             ),
         )
 
-        ts = TestSet.objects.get(name='TestSetB')
-        self.assertEqual(ts.name, 'TestSetB')
-        self.assertTrue(ts.src_file.name.endswith('.txt'))
-        self.assertTrue(ts.ref_file.name.endswith('.txt'))
+        tst = TestSet.objects.get(name='TestSetB')
+        self.assertEqual(tst.name, 'TestSetB')
+        self.assertTrue(tst.src_file.name.endswith('.txt'))
+        self.assertTrue(tst.ref_file.name.endswith('.txt'))
 
 
 class LeaderboardTests(TestCase):
@@ -112,13 +110,13 @@ class LeaderboardTests(TestCase):
         l_de = Language.objects.create(code='de', name='German')
 
         _next_year = datetime.now().year + 1
-        c1 = Competition.objects.create(
+        comp_a = Competition.objects.create(
             name='Competition A',
             description='Description of the competition A',
             deadline=datetime(_next_year, 1, 1, tzinfo=timezone.utc),
         )
 
-        ts1 = TestSet.objects.create(
+        test_a = TestSet.objects.create(
             is_active=True,
             name='TestSet A',
             source_language=l_en,
@@ -131,9 +129,9 @@ class LeaderboardTests(TestCase):
                 TESTDATA_DIR, 'newstest2019-ende-ref.de.sgm'
             ),
         )
-        c1.test_sets.add(ts1)
+        comp_a.test_sets.add(test_a)
 
-        t1 = Team.objects.create(
+        team_a = Team.objects.create(
             is_active=True,
             name='Team A',
             email='team-a@email.com',
@@ -143,13 +141,13 @@ class LeaderboardTests(TestCase):
         Submission.objects.create(
             name=_file1,
             original_name=_file1,
-            test_set=ts1,
-            submitted_by=t1,
+            test_set=test_a,
+            submitted_by=team_a,
             file_format=TEXT_FILE,
             hyp_file=os.path.join(TESTDATA_DIR, _file1),
         )
 
-        t2 = Team.objects.create(
+        team_b = Team.objects.create(
             is_active=True,
             name='Team B',
             email='team-b@email.com',
@@ -159,8 +157,8 @@ class LeaderboardTests(TestCase):
         Submission.objects.create(
             name=_file2,
             original_name=_file2,
-            test_set=ts1,
-            submitted_by=t2,
+            test_set=test_a,
+            submitted_by=team_b,
             file_format=TEXT_FILE,
             hyp_file=os.path.join(TESTDATA_DIR, _file2),
         )


### PR DESCRIPTION
Adding basic unit tests for models and frontpage and leaderboardpage views.

Changes proposed in the pull request:
- Added test data for creating test sets and submissions: WMT19 en-de test set truncated to 75 lines.
- Added unit tests.

GitHub checks fails because pylint complains a lot that `E1101: Class 'XYZ' has no 'objects' member (no-member)`, but this is properly handled and fixed in #18.

Please note that this PR is added on top of #16 and wants to be merged there. It's not opened towards master to see the changes better.

@AppraiseDev/core-team
