### PR TITLE
Update Python requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+black
+mypy
+pylint
+pylint-django
+reorder-python-imports
+safety

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-beautifulsoup4==4.9.3
-django==2.2.17
-django-stubs==1.7.0
-lxml==4.6.2
+beautifulsoup4
+Django>=3.0
+django-stubs
+lxml
 sacrebleu==1.4.10
-sqlparse==0.4.1
-xmlschema==1.3.1
+sqlparse
+xmlschema


### PR DESCRIPTION
Fixes #21.

Changes proposed in the pull request:
- Updated requirements with Django 3.
- Using version requirements only when it's needed and fallback to module dependencies otherwise. Freezing all modules is not a good practice unless it's for testing the exact production settings, but that should be in a separate file, e.g. `requirements-prod.txt`.
- Added requirements for development. We can use them in the GitHub pipelines, see #18.

SacreBLEU 1.4 is required because the API has changed in 1.5 (current newest).

@AppraiseDev/core-team
