### PR TITLE
Update on submissions in text format

### DIFF
--- a/leaderboard/templates/leaderboard/updates.html
+++ b/leaderboard/templates/leaderboard/updates.html
@@ -27,6 +27,7 @@
         <h2>Competition updates</h2>
         <p>
           <ul>
+            <li><em>11/6/2021:</em> We strongly recommend submitting system outputs in the XML format. Submissions in plain text must not include translations of test suites, so they would need to be excluded manually.</li>
             <li><em>10/6/2021:</em> Team registration is online and newstest2021 test set source data has been released.</li>
           </ul>
         </p>


### PR DESCRIPTION
A new update for WMT21: recommend submissions in XML + explain potential issues when submitting in text format.

@AppraiseDev/core-team
