### PR TITLE
A new competition update 14/6/2021

### DIFF
--- a/leaderboard/templates/leaderboard/updates.html
+++ b/leaderboard/templates/leaderboard/updates.html
@@ -27,8 +27,9 @@
         <h2>Competition updates</h2>
         <p>
           <ul>
+            <li><em>14/6/2021:</em> We have 47 verified teams and 126 submissions so far.</li>
             <li><em>11/6/2021:</em> We have updated the XML schema and submissions created with the official wrapping/unwrapping scripts work now. Please use the newest scripts from <a href="https://github.com/wmt-conference/wmt-format-tools">https://github.com/wmt-conference/wmt-format-tools</a> when preparing your submission.</li>
-            <li><em>11/6/2021:</em> We strongly recommend submitting system outputs in the XML format. Submissions in plain text must not include translations of test suites, so they would need to be excluded manually.</li>
+            <li><em>11/6/2021:</em> We strongly recommend submitting system outputs in the XML format. Submissions in plain text must not include translations of test suites.</li>
             <li><em>10/6/2021:</em> Team registration is online and newstest2021 test set source data has been released.</li>
           </ul>
         </p>


### PR DESCRIPTION
Changes proposed in the pull request:
- Adding a new update mentioning the number of verified teams so far.
- Changing one of the previous updates, following @kocmitom's suggestion.

@AppraiseDev/core-team
