### PR TITLE
Add ordering for LanguageAdmin class

### DIFF
--- a/leaderboard/admin.py
+++ b/leaderboard/admin.py
@@ -65,6 +65,8 @@ class LanguageAdmin(admin.ModelAdmin):
 
     fields = ['code', 'name']
 
+    ordering = ('name',)
+
 
 class SubmissionAdmin(admin.ModelAdmin):
     """Model admin for Submission objects."""


### PR DESCRIPTION
Use `name` instead of `id` for ordering of `LanguageAdmin`.