### PR TITLE
Extending hint about the file extension error

### DIFF
--- a/leaderboard/views.py
+++ b/leaderboard/views.py
@@ -316,7 +316,8 @@ def submit(request):
             else:
                 _msg = (
                     'Unsuccessful submission of {0}. '
-                    'Please check the format of the submitted file.'.format(
+                    'Please check the format of the submitted file. '
+                    'Does the submitted file have a .xml extension?'.format(
                         new_submission.hyp_file.name
                     )
                 )


### PR DESCRIPTION
Helps with #https://github.com/AppraiseDev/OCELoT/issues/87
Although it would be better not to keep checking the file extension.

@AppraiseDev/core-team
