### PR TITLE
No longer automatically selecting primary system

### DIFF
--- a/leaderboard/templates/leaderboard/updates.html
+++ b/leaderboard/templates/leaderboard/updates.html
@@ -37,7 +37,6 @@
           <ul>
             <li>We only accept submissions from verified teams &mdash; you will <strong>have to contact us</strong> (<code>tomkocmi@microsoft.com</code>) to verify your team account;</li>
             <li>Each team may upload <strong>up to {{ MAX_SUBMISSION_LIMIT }} submissions per language pair</strong>, without any time contraints between such uploads;</li>
-            <li>If you fail to designate your primary submission, your <strong>highest-scoring submission will be the default</strong>;</li>
             <li>We request that you do not create multiple teams to game these submission rules &mdash; we trust and thank you!</li>
           </ul>
         </p>


### PR DESCRIPTION
As discussed, we are not selecting primary systems automatically based on the scores. This was the last mention of the rule.