### PR TITLE
Action for downloading a JSON with teams and primary submissions

### DIFF
--- a/leaderboard/admin.py
+++ b/leaderboard/admin.py
@@ -144,8 +144,12 @@ def download_team_file(modeladmin, request, queryset):
             ],
         )
 
-        primary_submissions = team.submission_set.filter(is_primary=True, score__gte=0)
-        team_data['number_of_primary_submissions'] = len(primary_submissions)
+        primary_submissions = team.submission_set.filter(
+            is_primary=True, score__gte=0
+        )
+        team_data['number_of_primary_submissions'] = len(
+            primary_submissions
+        )
 
         submission_list = []
         for submission in primary_submissions:
@@ -160,8 +164,12 @@ def download_team_file(modeladmin, request, queryset):
                     'score_chrf',
                 ],
             )
-            submission_data['competition'] = submission.test_set.competition.name
-            submission_data['file_name'] = _make_submission_filename(submission)
+            submission_data[
+                'competition'
+            ] = submission.test_set.competition.name
+            submission_data['file_name'] = _make_submission_filename(
+                submission
+            )
             submission_data['test_set'] = submission.test_set.name
             language_pair = "{0}-{1}".format(
                 submission.test_set.source_language.code,

--- a/leaderboard/admin.py
+++ b/leaderboard/admin.py
@@ -156,7 +156,6 @@ def download_team_file(modeladmin, request, queryset):
             submission_data = model_to_dict(
                 submission,
                 fields=[
-                    'id',
                     'is_constrained',
                     'is_primary',
                     'is_removed',
@@ -170,6 +169,7 @@ def download_team_file(modeladmin, request, queryset):
             submission_data['file_name'] = _make_submission_filename(
                 submission
             )
+            submission_data['submission_id'] = submission.id
             submission_data['test_set'] = submission.test_set.name
             language_pair = "{0}-{1}".format(
                 submission.test_set.source_language.code,

--- a/leaderboard/admin.py
+++ b/leaderboard/admin.py
@@ -1,12 +1,14 @@
 """
 Project OCELoT: Open, Competitive Evaluation Leaderboard of Translations
 """
+import json
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
 
 from django.contrib import admin
+from django.forms.models import model_to_dict
 from django.http import FileResponse
 
 from leaderboard.models import Competition
@@ -14,6 +16,25 @@ from leaderboard.models import Language
 from leaderboard.models import Submission
 from leaderboard.models import Team
 from leaderboard.models import TestSet
+
+
+def _make_submission_filename(submission):
+    """Creates a readable filename for a submission."""
+    publication_name = submission.submitted_by.publication_name
+    if not submission.submitted_by.publication_name:
+        publication_name = submission.name
+
+    file_extension = submission.hyp_file.name.split('.')[-1]
+
+    filename = 'submissions/{0}.{1}-{2}.{3}.{4}.{5}'.format(
+        submission.test_set.name,
+        submission.test_set.source_language.code,
+        submission.test_set.target_language.code,
+        publication_name,
+        submission.id,
+        file_extension,
+    )
+    return filename.replace(' ', '_').lower()
 
 
 def download_submission_files(modeladmin, request, queryset):
@@ -24,22 +45,7 @@ def download_submission_files(modeladmin, request, queryset):
     tmp_file = NamedTemporaryFile(delete=False)
     with ZipFile(tmp_file, 'w', ZIP_DEFLATED) as zip_file:
         for submission in queryset:
-            publication_name = submission.submitted_by.publication_name
-            if not submission.submitted_by.publication_name:
-                publication_name = submission.name
-
-            file_extension = submission.hyp_file.name.split('.')[-1]
-
-            new_filename = 'submissions/{0}.{1}-{2}.{3}.{4}.{5}'.format(
-                submission.test_set.name,
-                submission.test_set.source_language.code,
-                submission.test_set.target_language.code,
-                publication_name,
-                submission.id,
-                file_extension,
-            )
-            new_filename.replace(' ', '_').lower()
-
+            new_filename = _make_submission_filename(submission)
             zip_file.writestr(
                 Path(new_filename).name,
                 submission.hyp_file.open('rb').read(),
@@ -119,8 +125,78 @@ class SubmissionAdmin(admin.ModelAdmin):
     )
 
 
+def download_team_file(modeladmin, request, queryset):
+    """Creates JSON file with team information for queryset."""
+    del modeladmin  # unused
+    del request  # unused
+
+    team_list = []
+    for team in queryset:
+        team_data = model_to_dict(
+            team,
+            fields=[
+                'description',
+                'email',
+                'institution_name',
+                'name',
+                'publication_name',
+                'publication_url',
+            ],
+        )
+
+        primary_submissions = team.submission_set.filter(is_primary=True, score__gte=0)
+        team_data['number_of_primary_submissions'] = len(primary_submissions)
+
+        submission_list = []
+        for submission in primary_submissions:
+            submission_data = model_to_dict(
+                submission,
+                fields=[
+                    'id',
+                    'is_constrained',
+                    'is_primary',
+                    'is_removed',
+                    'score',
+                    'score_chrf',
+                ],
+            )
+            submission_data['competition'] = submission.test_set.competition.name
+            submission_data['file_name'] = _make_submission_filename(submission)
+            submission_data['test_set'] = submission.test_set.name
+            language_pair = "{0}-{1}".format(
+                submission.test_set.source_language.code,
+                submission.test_set.target_language.code,
+            )
+            submission_data['language_pair'] = language_pair
+            submission_list.append(submission_data)
+        team_data['primary_submissions'] = submission_list
+
+        team_list.append(team_data)
+    team_json = json.dumps(list(team_list), indent=2, sort_keys=True)
+
+    tmp_file = NamedTemporaryFile(delete=False)
+    with ZipFile(tmp_file, 'w', ZIP_DEFLATED) as zip_file:
+        zip_file.writestr('teams.json', team_json)
+
+    tmp_file.seek(0)
+    response = FileResponse(
+        open(tmp_file.name, 'rb'),
+        as_attachment=True,
+        content_type='application/x-zip-compressed',
+        filename='teams.zip',
+    )
+    return response
+
+
+download_team_file.short_description = (  # type: ignore
+    "Download JSON file with primary submissions for selected teams"
+)
+
+
 class TeamAdmin(admin.ModelAdmin):
     """Model admin for Team objects."""
+
+    actions = [download_team_file]
 
     fields = [
         'name',


### PR DESCRIPTION
Fixes #99 by adding an action to `Team` in the admin panel for downloading a JSON file with all information.

Example from the JSON file:
```
  ...
  {
    "description": "Example description",
    "email": "example@email.com",
    "institution_name": "Example institution name",
    "name": "example-team",
    "number_of_primary_submissions": 4,
    "primary_submissions": [
      {
        "competition": "Example competition",
        "file_name": "File name as in the other action",
        "submission_id": 5,
        "is_constrained": true,
        "is_primary": true,
        "is_removed": false,
        "language_pair": "en-de",
        "score": 41.81726032290008,
        "score_chrf": 0.6571380314701315,
        "test_set": "exampletestset.en-de"
      },
      ...
```

@AppraiseDev/core-team
