### PR TITLE
Accept optional 'domain' attribute in XML submissions

### DIFF
--- a/leaderboard/models.py
+++ b/leaderboard/models.py
@@ -171,6 +171,12 @@ XML_RNG_SCHEMA = """<?xml version="1.0" encoding="UTF-8"?>
           <data type="string"/>
         </attribute>
       </optional>
+      <optional>
+        <attribute>
+          <name ns="">domain</name>
+          <data type="string"/>
+        </attribute>
+      </optional>
       <ref name="Source"/>
       <zeroOrMore>
         <ref name="Reference"/>


### PR DESCRIPTION
It seems it wasn't accepted in team submissions, but likely should.

@AppraiseDev/core-team
